### PR TITLE
allow third party hubs to be used with EVENTLET_HUB environment variable.

### DIFF
--- a/eventlet/hubs/__init__.py
+++ b/eventlet/hubs/__init__.py
@@ -8,7 +8,7 @@ try:
     import pkg_resources
 except ImportError:
     # ... but do not depend on it
-    pass
+    pkg_resources = None
 
 
 __all__ = ["use_hub", "get_hub", "get_default_hub", "trampoline"]
@@ -81,13 +81,9 @@ def use_hub(mod=None):
                 mod = getattr(mod, classname)
         else:
             found = False
-            try:
-                iter_entry_points = pkg_resources.iter_entry_points
-            except NameError:
-                # no pkg_resources module installed
-                pass
-            else:
-                for entry in iter_entry_points(group='eventlet.hubs', name=mod):
+            if pkg_resources is not None:
+                for entry in pkg_resources.iter_entry_points(
+                        group='eventlet.hubs', name=mod):
                     mod, found = entry.load(), True
                     break
             if not found:


### PR DESCRIPTION
This change allows the use of third-party hubs with the `EVENTLET_HUB` environment variable, which greatly improves the ability to test those hubs against the eventlet testcases with nosetests as well as switching to those hubs without using `use_hub()` explicitly.

It adds the ability to do the following:
- if there's a dot present in the hub name then it will attempt to import that module without prepending `eventlet.hubs`:
  
  `$ EVENTLET_HUB=somepackage.hubmodule nosetests`
- if there is a colon it uses the package.subpackage.module:Class convention to import the hub class:
  
  `$ EVENTLET_HUB=hubmodule:Hub nosetests`
- and finally, extending the simple module syntax, it will look up name in a setuptools/distribute entry point group 'eventlet.hubs' (though this is only used if the setuptools/distribute provided `pkg_resources` module is found, it doesn't depend on it being there):
  
  `$ EVENTLET_HUB=name nosetests`

which can be registered by module with the following in their setup.py:

```
entry_points = {'eventlet.hubs': 'name = somepackage.hubmodule:Hub', }
```

and if that fails, it imports the hub using `eventlet.hubs.%(name)s` as before...
