### PR TITLE
eventlet.green.subprocess blocks on python 2.7

### DIFF
--- a/eventlet/green/subprocess.py
+++ b/eventlet/green/subprocess.py
@@ -57,6 +57,15 @@ class Popen(subprocess_orig.Popen):
         try:
             _communicate = new.function(subprocess_orig.Popen._communicate.im_func.func_code,
                                         globals())
+            try:
+                _communicate_with_select = new.function(
+                    subprocess_orig.Popen._communicate_with_select.im_func.func_code,
+                    globals())
+                _communicate_with_poll = new.function(
+                    subprocess_orig.Popen._communicate_with_poll.im_func.func_code,
+                    globals())
+            except AttributeError:
+                pass
         except AttributeError:
             # 2.4 only has communicate
             _communicate = new.function(subprocess_orig.Popen.communicate.im_func.func_code,


### PR DESCRIPTION
`eventlet.green.subprocess.Popen.communicate()` was broken in python 2.7 because the usage of the `select` module was moved from `_communicate` into two other methods `_communicate_with_select` and `_communicate_with_poll`. (link to 2.7's implementation: http://hg.python.org/cpython/file/2145593d108d/Lib/subprocess.py#l1255 )

we currently patch only `_communicate`'s globals: https://github.com/eventlet/eventlet/blob/master/eventlet/green/subprocess.py#L58
this changeset also patches the two new functions.

it's fairly hard to test because `select.select` seems to block `SIGALARM`, I couldn't get `debug.hub_blocking_detection()` to fire whilst the code was being blocked on my darwin system. (we don't actually have any current tests for this module, we run stdlib's)

it can be demonstrated here with a nice deadlock: https://gist.github.com/edwardgeorge/5323231
