### PR TITLE
clear up some references left lying around in tpool

### DIFF
--- a/eventlet/tpool.py
+++ b/eventlet/tpool.py
@@ -54,7 +54,7 @@ def tpool_trampoline():
             try:
                 (e,rv) = _rspq.get(block=False)
                 e.send(rv)
-                rv = None
+                e = rv = None
             except Empty:
                 pass
 
@@ -82,7 +82,7 @@ def tworker():
         # test_leakage_from_tracebacks verifies that the use of
         # exc_info does not lead to memory leaks
         _rspq.put((e,rv))
-        meth = args = kwargs = e = rv = None
+        msg = meth = args = kwargs = e = rv = None
         _signal_t2e()
 
 


### PR DESCRIPTION
this fixes the issue seen in the failing build https://travis-ci.org/eventlet/eventlet/builds/7725869 for me.

As this test is now hitting more than one thread in the threadpool it was exposing a bug whereby a tpool worker would keep some references lying around until next usage, which in this case was preventing cleanup of the db connections in the test tearDown.
