### PR TITLE
Add pep8 and flake8 configuration in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,11 @@
+[pep8]
+ignore = E261
+max-line-length = 101
+
+[flake8]
+ignore = E261
+max-line-length = 101
+
 [tox]
 envlist = py25selects,py25poll,py26selects,py26poll,py26epolls,py27selects,py27poll,py27epolls
 


### PR DESCRIPTION
This helps ensuring everyone uses the code checkers with the same
configuration.  Initial values based on earlier discussion.  The
max-line-length is currently just based on the screen with I have
on my netbook.
