### PR TITLE
Proposed fix for BitBucket Issue #157

### DIFF
--- a/tests/backdoor_test.py
+++ b/tests/backdoor_test.py
@@ -1,7 +1,8 @@
 import eventlet
 from eventlet import backdoor
 from eventlet.green import socket
-
+import os
+import os.path
 from tests import LimitedTestCase, main
 
 class BackdoorTest(LimitedTestCase):
@@ -27,7 +28,55 @@ class BackdoorTest(LimitedTestCase):
         serv.kill()
         # wait for the console to discover that it's dead
         eventlet.sleep(0.1)
-        
+    def test_server_On_ipv6_socket(self):
+        listener = socket.socket(socket.AF_INET6)
+        listener.bind(('::1',0))
+        listener.listen(5)
+        serv = eventlet.spawn(backdoor.backdoor_server, listener)
+        client = socket.socket(socket.AF_INET6)
+        client.connect(listener.getsockname())
+        f = client.makefile('rw')
+        self.assert_('Python' in f.readline())
+        f.readline()  # build info
+        f.readline()  # help info
+        self.assert_('InteractiveConsole' in f.readline())
+        self.assertEquals('>>> ', f.read(4))
+        f.write('print("hi")\n')
+        f.flush()
+        self.assertEquals('hi\n', f.readline())
+        self.assertEquals('>>> ', f.read(4))
+        f.write('exit()\n')
+        f.close()
+        client.close()
+        serv.kill()
+        # wait for the console to discover that it's dead
+        eventlet.sleep(0.1)
+    def test_server_on_unix_socket(self):
+        SOCKET_PATH = '/tmp/eventlet_backdoor_test.socket'
+        if os.path.exists(SOCKET_PATH):
+            os.unlink(SOCKET_PATH)
+        listener = socket.socket(socket.AF_UNIX)
+        listener.bind(SOCKET_PATH)
+        listener.listen(5)
+        serv = eventlet.spawn(backdoor.backdoor_server, listener)
+        client = socket.socket(socket.AF_UNIX)
+        client.connect(SOCKET_PATH)
+        f = client.makefile('rw')
+        self.assert_('Python' in f.readline())
+        f.readline()  # build info
+        f.readline()  # help info
+        self.assert_('InteractiveConsole' in f.readline())
+        self.assertEquals('>>> ', f.read(4))
+        f.write('print("hi")\n')
+        f.flush()
+        self.assertEquals('hi\n', f.readline())
+        self.assertEquals('>>> ', f.read(4))
+        f.write('exit()\n')
+        f.close()
+        client.close()
+        serv.kill()
+        # wait for the console to discover that it's dead
+        eventlet.sleep(0.1)
         
 
 if __name__ == '__main__':


### PR DESCRIPTION
I have taken a stab at fixing bit bucket issue #157. A couple points

1. This code uses the 'print' function directly. I'm not sure if that is desirable, but I opted not to factor that out at this time.
2. Issue #157 was about unix domain sockets, I believe I have fixed it. I opted to try and make backdoor compatible with IPv6 at the same time.
3. I had to add a catch for BaseException in the call to InteractiveConsole.interact in order to make unit tests pass. The exception is printed when finalize is called. There may be a better way and I welcome any suggestions.
4. I probably broke some coding standard in this. I don't think I let any tabs slip in at least.