### PR TITLE
fix interpreter shutdown message

### DIFF
--- a/eventlet/db_pool.py
+++ b/eventlet/db_pool.py
@@ -231,7 +231,7 @@ class BaseConnectionPool(Pool):
         """
         if self._expiration_timer:
             self._expiration_timer.cancel()
-        free_items, self.free_items = self.free_items, deque()
+        free_items, self.free_items = self.free_items, deque() if deque else None
         for item in free_items:
             # Free items created using min_size>0 are not tuples.
             conn = item[2] if isinstance(item, tuple) else item


### PR DESCRIPTION
Sometimes, during shutdown, this code is executed when deque no longer exists, which produces an unhelpful error message.
