### PR TITLE
Use six to make xrange work across python 2 and 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
   - TOX_ENV=py27selects
   - TOX_ENV=py27poll
   - TOX_ENV=py27epolls
+  - TOX_ENV=py33selects
+  - TOX_ENV=py33poll
+  - TOX_ENV=py33epolls
 install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libssl-dev libmysqlclient-dev libpq-dev

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,6 +1,7 @@
 import gc
 import timeit
 import random
+import six
     
 def measure_best(repeat, iters, 
                  common_setup='pass', 
@@ -9,7 +10,7 @@ def measure_best(repeat, iters,
     funcs = list(funcs)
     results = dict([(f,[]) for f in funcs])
 
-    for i in xrange(repeat):
+    for i in six.moves.range(repeat):
         random.shuffle(funcs)
         for func in funcs:
             gc.collect()

--- a/benchmarks/hub_timers.py
+++ b/benchmarks/hub_timers.py
@@ -7,6 +7,7 @@ import sys
 import eventlet
 import random
 import time
+import six
 from eventlet.hubs import timer, get_hub
 
 timer_count = 100000
@@ -19,7 +20,7 @@ l = []
 def work(n):
     l.append(n)
 
-timeouts = [random.uniform(0, 10) for x in xrange(timer_count)]
+timeouts = [random.uniform(0, 10) for x in six.moves.range(timer_count)]
 
 hub = get_hub()
 

--- a/benchmarks/localhost_socket.py
+++ b/benchmarks/localhost_socket.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 import time
-
+import six
 import benchmarks
 
 
@@ -30,13 +30,13 @@ def writer(addr, socket_impl):
 
 
 def green_accepter(server_sock, pool):
-    for i in xrange(CONCURRENCY):
+    for i in six.moves.range(CONCURRENCY):
         sock, addr = server_sock.accept()
         pool.spawn_n(reader, sock)
 
 
 def heavy_accepter(server_sock, pool):
-    for i in xrange(CONCURRENCY):
+    for i in six.moves.range(CONCURRENCY):
         sock, addr = server_sock.accept()
         t = threading.Thread(None, reader, "reader thread", (sock,))
         t.start()
@@ -57,7 +57,7 @@ def launch_green_threads():
     server_sock.listen(50)
     addr = ('localhost', server_sock.getsockname()[1])
     pool.spawn_n(green_accepter, server_sock, pool)
-    for i in xrange(CONCURRENCY):
+    for i in six.moves.range(CONCURRENCY):
         pool.spawn_n(writer, addr, eventlet.green.socket.socket)
     pool.waitall()
 
@@ -75,7 +75,7 @@ def launch_heavy_threads():
     accepter_thread = threading.Thread(None, heavy_accepter, "accepter thread", (server_sock, threads))
     accepter_thread.start()
     threads.append(accepter_thread)
-    for i in xrange(CONCURRENCY):
+    for i in six.moves.range(CONCURRENCY):
         client_thread = threading.Thread(None, writer, "writer thread", (addr, socket.socket))
         client_thread.start()
         threads.append(client_thread)

--- a/eventlet/pools.py
+++ b/eventlet/pools.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import collections
 from contextlib import contextmanager
+import six
 
 from eventlet import queue
 
@@ -71,7 +72,7 @@ class Pool(object):
         if create is not None:
             self.create = create
 
-        for x in xrange(min_size):
+        for x in six.moves.range(min_size):
             self.current_size += 1
             self.free_items.append(self.create())
 

--- a/eventlet/tpool.py
+++ b/eventlet/tpool.py
@@ -16,6 +16,7 @@
 import imp
 import os
 import sys
+import six
 
 from eventlet import event
 from eventlet import greenio
@@ -263,7 +264,7 @@ def setup():
         warnings.warn("Zero threads in tpool.  All tpool.execute calls will\
             execute in main thread.  Check the value of the environment \
             variable EVENTLET_THREADPOOL_SIZE.", RuntimeWarning)
-    for i in xrange(_nthreads):
+    for i in six.moves.range(_nthreads):
         t = threading.Thread(target=tworker,
                              name="tpool_thread_%s" % i)
         t.setDaemon(True)

--- a/examples/websocket.py
+++ b/examples/websocket.py
@@ -5,6 +5,7 @@ from eventlet import websocket
 # demo app
 import os
 import random
+import six
 
 @websocket.WebSocketWSGI
 def handle(ws):
@@ -18,7 +19,7 @@ def handle(ws):
             ws.send(m)
             
     elif ws.path == '/data':
-        for i in xrange(10000):
+        for i in six.moves.range(10000):
             ws.send("0 %s %s\n" % (i, random.random()))
             eventlet.sleep(0.1)
                   

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import unittest
 import warnings
+import six
 
 import eventlet
 from eventlet import debug, hubs, tpool

--- a/tests/convenience_test.py
+++ b/tests/convenience_test.py
@@ -1,4 +1,5 @@
 import os
+import six
 
 import eventlet
 from eventlet import event
@@ -65,7 +66,7 @@ class TestServe(LimitedTestCase):
             hits[0]+=1
         l = eventlet.listen(('localhost', 0))
         gt = eventlet.spawn(eventlet.serve, l, counter)
-        for i in xrange(100):
+        for i in six.moves.range(100):
             client = eventlet.connect(('localhost', l.getsockname()[1]))
             self.assertFalse(client.recv(100))            
         gt.kill()
@@ -100,7 +101,7 @@ class TestServe(LimitedTestCase):
             # verify the client is connected by getting data
             self.assertEquals(s2b('hi'), c.recv(2))
             return c
-        clients = [test_client() for i in xrange(5)]
+        clients = [test_client() for i in six.moves.range(5)]
         # very next client should not get anything
         x = eventlet.with_timeout(0.01,
             test_client,

--- a/tests/db_pool_test.py
+++ b/tests/db_pool_test.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import sys
 import os
 import traceback
+import six
 from unittest import TestCase, main
 
 from tests import skipped, skip_unless, skip_with_pyevent, get_database_auth
@@ -419,12 +420,12 @@ class DBConnectionPool(DBTester):
         c = self.connection.cursor()
         self.connection.commit()
         def bench(c):
-            for i in xrange(iterations):
+            for i in six.moves.range(iterations):
                 c.execute('select 1')
 
         bench(c)  # warm-up
         results = []
-        for i in xrange(3):
+        for i in six.moves.range(3):
             start = time.time()
             bench(c)
             end = time.time()

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -1,4 +1,5 @@
 import os
+import six
 from tests.patcher_test import ProcessBase
 from tests import skip_with_pyevent
 
@@ -24,6 +25,7 @@ class Tpool(ProcessBase):
         new_mod = """from eventlet import tpool
 import eventlet
 import time
+import six
 current = [0]
 highwater = [0]
 def count():
@@ -35,7 +37,7 @@ def count():
 expected = %s
 normal = %s
 p = eventlet.GreenPool()
-for i in xrange(expected*2):
+for i in six.moves.range(expected*2):
     p.spawn(tpool.execute, count)
 p.waitall()
 assert highwater[0] > 20, "Highwater %%s  <= %%s" %% (highwater[0], normal)

--- a/tests/greenio_test.py
+++ b/tests/greenio_test.py
@@ -11,6 +11,7 @@ import eventlet
 import fcntl
 import os
 import sys
+import six
 import tempfile, shutil
 
 
@@ -626,7 +627,7 @@ class TestGreenPipe(LimitedTestCase):
 
         one_line = "12345\n"
         eventlet.spawn(sender, wf, one_line * 5)
-        for i in xrange(5):
+        for i in six.moves.range(5):
             line = rf.readline()
             eventlet.sleep(0.01)
             self.assertEquals(line, one_line)
@@ -668,7 +669,7 @@ class TestGreenPipe(LimitedTestCase):
         r = greenio.GreenPipe(r)
         w = greenio.GreenPipe(w, 'w')
 
-        large_message = "".join([1024 * chr(i) for i in xrange(65)])
+        large_message = "".join([1024 * chr(i) for i in six.moves.range(65)])
 
         def writer():
             w.write(large_message)
@@ -676,7 +677,7 @@ class TestGreenPipe(LimitedTestCase):
 
         gt = eventlet.spawn(writer)
 
-        for i in xrange(65):
+        for i in six.moves.range(65):
             buf = r.read(1024)
             expected = 1024 * chr(i)
             self.assertEquals(buf, expected,
@@ -790,7 +791,7 @@ class TestGreenIoStarvation(LimitedTestCase):
         recvsize = 2 * min_buf_size()
         sendsize = 10000 * recvsize
 
-        results = [[] for i in xrange(5)]
+        results = [[] for i in six.moves.range(5)]
 
         listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/tests/greenpool_test.py
+++ b/tests/greenpool_test.py
@@ -1,7 +1,8 @@
 import gc
 import itertools
 import os
-import random 
+import random
+import six
 
 import eventlet
 from eventlet import debug
@@ -24,10 +25,10 @@ class GreenPool(tests.LimitedTestCase):
     def test_spawn(self):
         p = greenpool.GreenPool(4)
         waiters = []
-        for i in xrange(10):
+        for i in six.moves.range(10):
             waiters.append(p.spawn(passthru, i))
         results = [waiter.wait() for waiter in waiters]
-        self.assertEquals(results, list(xrange(10)))
+        self.assertEquals(results, list(six.moves.range(10)))
 
     def test_spawn_n(self):
         p = greenpool.GreenPool(4)
@@ -35,7 +36,7 @@ class GreenPool(tests.LimitedTestCase):
         def do_something(a):
             eventlet.sleep(0.01)
             results_closure.append(a)
-        for i in xrange(10):
+        for i in six.moves.range(10):
             p.spawn(do_something, i)
         p.waitall()
         self.assertEquals(results_closure, range(10))
@@ -123,7 +124,7 @@ class GreenPool(tests.LimitedTestCase):
         timer = eventlet.Timeout(1)
         try:
             evt = event.Event()
-            for x in xrange(num_free):
+            for x in six.moves.range(num_free):
                 pool.spawn(wait_long_time, evt)
                 # if the pool has fewer free than we expect,
                 # then we'll hit the timeout error
@@ -254,8 +255,8 @@ class GreenPool(tests.LimitedTestCase):
 
     def test_imap(self):
         p = greenpool.GreenPool(4)
-        result_list = list(p.imap(passthru, xrange(10)))
-        self.assertEquals(result_list, list(xrange(10)))
+        result_list = list(p.imap(passthru, six.moves.range(10)))
+        self.assertEquals(result_list, list(six.moves.range(10)))
         
     def test_empty_imap(self):
         p = greenpool.GreenPool(4)
@@ -264,13 +265,13 @@ class GreenPool(tests.LimitedTestCase):
         
     def test_imap_nonefunc(self):
         p = greenpool.GreenPool(4)
-        result_list = list(p.imap(None, xrange(10)))
-        self.assertEquals(result_list, [(x,) for x in xrange(10)])
+        result_list = list(p.imap(None, six.moves.range(10)))
+        self.assertEquals(result_list, [(x,) for x in six.moves.range(10)])
         
     def test_imap_multi_args(self):
         p = greenpool.GreenPool(4)
-        result_list = list(p.imap(passthru2, xrange(10), xrange(10, 20)))
-        self.assertEquals(result_list, list(itertools.izip(xrange(10), xrange(10,20))))
+        result_list = list(p.imap(passthru2, six.moves.range(10), six.moves.range(10, 20)))
+        self.assertEquals(result_list, list(itertools.izip(six.moves.range(10), six.moves.range(10,20))))
 
     def test_imap_raises(self):
         # testing the case where the function raises an exception;
@@ -282,7 +283,7 @@ class GreenPool(tests.LimitedTestCase):
                 raise RuntimeError("intentional error")
             else:
                 return item
-        it = p.imap(raiser, xrange(10))
+        it = p.imap(raiser, six.moves.range(10))
         results = []
         while True:
             try:
@@ -295,7 +296,7 @@ class GreenPool(tests.LimitedTestCase):
         
     def test_starmap(self):
         p = greenpool.GreenPool(4)
-        result_list = list(p.starmap(passthru, [(x,) for x in xrange(10)]))
+        result_list = list(p.starmap(passthru, [(x,) for x in six.moves.range(10)]))
         self.assertEquals(result_list, range(10))
 
     def test_waitall_on_nothing(self):
@@ -311,36 +312,36 @@ class GreenPool(tests.LimitedTestCase):
 class GreenPile(tests.LimitedTestCase):
     def test_pile(self):
         p = greenpool.GreenPile(4)
-        for i in xrange(10):
+        for i in six.moves.range(10):
             p.spawn(passthru, i)
         result_list = list(p)
-        self.assertEquals(result_list, list(xrange(10)))
+        self.assertEquals(result_list, list(six.moves.range(10)))
         
     def test_pile_spawn_times_out(self):
         p = greenpool.GreenPile(4)
-        for i in xrange(4):
+        for i in six.moves.range(4):
             p.spawn(passthru, i)
         # now it should be full and this should time out
         eventlet.Timeout(0)
         self.assertRaises(eventlet.Timeout, p.spawn, passthru, "time out")
         # verify that the spawn breakage didn't interrupt the sequence
         # and terminates properly
-        for i in xrange(4,10):
+        for i in six.moves.range(4,10):
             p.spawn(passthru, i)
-        self.assertEquals(list(p), list(xrange(10)))
+        self.assertEquals(list(p), list(six.moves.range(10)))
         
     def test_constructing_from_pool(self):
         pool = greenpool.GreenPool(2)
         pile1 = greenpool.GreenPile(pool)
         pile2 = greenpool.GreenPile(pool)
         def bunch_of_work(pile, unique):
-            for i in xrange(10):
+            for i in six.moves.range(10):
                 pile.spawn(passthru, i + unique)
         eventlet.spawn(bunch_of_work, pile1, 0)
         eventlet.spawn(bunch_of_work, pile2, 100)
         eventlet.sleep(0)
-        self.assertEquals(list(pile2), list(xrange(100,110)))
-        self.assertEquals(list(pile1), list(xrange(10)))
+        self.assertEquals(list(pile2), list(six.moves.range(100,110)))
+        self.assertEquals(list(pile1), list(six.moves.range(10)))
 
 
 class StressException(Exception):
@@ -368,7 +369,7 @@ class Stress(tests.LimitedTestCase):
         # checks that piles are strictly ordered
         p = greenpool.GreenPile(concurrency)
         def makework(count, unique):            
-            for i in xrange(count):
+            for i in six.moves.range(count):
                 token = (unique, i)
                 p.spawn(pressure, token)
         
@@ -409,7 +410,7 @@ class Stress(tests.LimitedTestCase):
         # ordered and consumes a constant amount of memory
         p = greenpool.GreenPool(concurrency)
         count = 1000
-        it = p.imap(passthru, xrange(count))
+        it = p.imap(passthru, six.moves.range(count))
         latest = -1
         while True:
             try:
@@ -456,7 +457,7 @@ class Stress(tests.LimitedTestCase):
             
             int_pool = IntPool(max_size=intpool_size)
             pool = greenpool.GreenPool(pool_size)
-            for ix in xrange(num_executes):
+            for ix in six.moves.range(num_executes):
                 pool.spawn(run, int_pool)
             pool.waitall()
             

--- a/tests/hub_test.py
+++ b/tests/hub_test.py
@@ -1,5 +1,6 @@
 from __future__ import with_statement
 import sys
+import six
 
 from tests import LimitedTestCase, main, skip_with_pyevent, skip_if_no_itimer, skip_unless
 from tests.patcher_test import ProcessBase
@@ -26,7 +27,7 @@ class TestTimerCleanup(LimitedTestCase):
         hub = hubs.get_hub()
         stimers = hub.get_timers_count()
         scanceled = hub.timers_canceled
-        for i in xrange(2000):
+        for i in six.moves.range(2000):
             t = hubs.get_hub().schedule_call_global(60, noop)
             t.cancel()
             self.assert_less_than_equal(hub.timers_canceled,
@@ -40,7 +41,7 @@ class TestTimerCleanup(LimitedTestCase):
         hub = hubs.get_hub()
         stimers = hub.get_timers_count()
         scanceled = hub.timers_canceled
-        for i in xrange(2000):
+        for i in six.moves.range(2000):
             t = hubs.get_hub().schedule_call_global(60, noop)
             eventlet.sleep()
             self.assert_less_than_equal(hub.timers_canceled,
@@ -60,7 +61,7 @@ class TestTimerCleanup(LimitedTestCase):
         uncanceled_timers = []
         stimers = hub.get_timers_count()
         scanceled = hub.timers_canceled
-        for i in xrange(1000):
+        for i in six.moves.range(1000):
             # 2/3rds of new timers are uncanceled
             t = hubs.get_hub().schedule_call_global(60, noop)
             t2 = hubs.get_hub().schedule_call_global(60, noop)

--- a/tests/patcher_psycopg_test.py
+++ b/tests/patcher_psycopg_test.py
@@ -1,4 +1,5 @@
 import os
+import six
 
 from tests import patcher_test, skip_unless
 from tests import get_database_auth
@@ -7,6 +8,7 @@ from tests.db_pool_test import postgres_requirement
 psycopg_test_file = """
 import os
 import sys
+import six
 import eventlet
 eventlet.monkey_patch()
 from eventlet import patcher
@@ -16,7 +18,7 @@ if not patcher.is_monkey_patched('psycopg'):
 
 count = [0]
 def tick(totalseconds, persecond):
-    for i in xrange(totalseconds*persecond):
+    for i in six.moves.range(totalseconds*persecond):
         count[0] += 1
         eventlet.sleep(1.0/persecond)
         

--- a/tests/patcher_test.py
+++ b/tests/patcher_test.py
@@ -3,6 +3,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import six
 
 from tests import LimitedTestCase, main, run_python, skip_with_pyevent
 
@@ -213,10 +214,12 @@ print "already_patched", ",".join(sorted(patcher.already_patched.keys()))
 
 
 test_monkey_patch_threading = """
+import six
+
 def test_monkey_patch_threading():
     tickcount = [0]
     def tick():
-        for i in xrange(1000):
+        for i in six.moves.range(1000):
             tickcount[0] += 1
             eventlet.sleep()
 
@@ -447,11 +450,11 @@ t2.join()
 """ + self.epilogue)
         output, lines = self.launch_subprocess('newmod')
         self.assertEqual(len(lines), 10, "\n".join(lines))
-        for i in xrange(0, 3):
+        for i in six.moves.range(0, 3):
             self.assertEqual(lines[i], "GreenThread-1", lines[i])
-        for i in xrange(3, 6):
+        for i in six.moves.range(3, 6):
             self.assertEqual(lines[i], "foo", lines[i])
-        for i in xrange(6, 9):
+        for i in six.moves.range(6, 9):
             self.assertEqual(lines[i], "bar", lines[i])
 
     def test_ident(self):

--- a/tests/pools_test.py
+++ b/tests/pools_test.py
@@ -1,3 +1,4 @@
+import six
 from unittest import TestCase, main
 
 import eventlet
@@ -111,7 +112,7 @@ class TestIntPool(TestCase):
             def just_put(pool_item, index):
                 self.pool.put(pool_item)
                 queue.put(index)
-            for index in xrange(size + 1):
+            for index in six.moves.range(size + 1):
                 pool_item = self.pool.get()
                 eventlet.spawn(just_put, pool_item, index)
 
@@ -153,7 +154,7 @@ class TestIntPool(TestCase):
             p.put(x)
 
         gp = eventlet.GreenPool()
-        for i in xrange(100):
+        for i in six.moves.range(100):
             gp.spawn_n(do_get)
         gp.waitall()
         self.assertEquals(creates[0], 4)

--- a/tests/test__pool.py
+++ b/tests/test__pool.py
@@ -1,3 +1,4 @@
+import six
 import eventlet
 import warnings
 warnings.simplefilter('ignore', DeprecationWarning)
@@ -105,7 +106,7 @@ class TestCoroutinePool(LimitedTestCase):
         timer = timeout.Timeout(1, api.TimeoutError)
         try:
             evt = _event.Event()
-            for x in xrange(num_free):
+            for x in six.moves.range(num_free):
                 pool.execute(wait_long_time, evt)
                 # if the pool has fewer free than we expect,
                 # then we'll hit the timeout error
@@ -288,7 +289,7 @@ class PoolBasicTests(LimitedTestCase):
             
             int_pool = IntPool(max_size=intpool_size)
             pool = self.klass(max_size=pool_size)
-            for ix in xrange(num_executes):
+            for ix in six.moves.range(num_executes):
                 pool.execute(run, int_pool)
             pool.waitall()
             

--- a/tests/test__proc.py
+++ b/tests/test__proc.py
@@ -1,3 +1,4 @@
+import six
 import sys
 import unittest
 import warnings
@@ -72,7 +73,7 @@ class TestProc(LimitedTestCase):
         p.link(event)
         self.assertEqual(event.wait(), 100)
 
-        for i in xrange(3):
+        for i in six.moves.range(3):
             event2 = _event.Event()
             p.link(event2)
             self.assertEqual(event2.wait(), 100)
@@ -156,7 +157,7 @@ class TestReturn_link(TestCase):
         p = self.p = proc.spawn(return25)
         self._test_return(p, True, 25, proc.LinkedCompleted, lambda : sleep(0))
         # repeating the same with dead process
-        for _ in xrange(3):
+        for _ in six.moves.range(3):
             self._test_return(p, False, 25, proc.LinkedCompleted, lambda : sleep(0))
 
     def _test_return(self, p, first_time, result, kill_exc_type, action):
@@ -221,7 +222,7 @@ class TestRaise_link(TestCase):
         p = self.p = proc.spawn(lambda : getcurrent().throw(ExpectedError('test_raise')))
         self._test_raise(p, True, proc.LinkedFailed)
         # repeating the same with dead process
-        for _ in xrange(3):
+        for _ in six.moves.range(3):
             self._test_raise(p, False, proc.LinkedFailed)
 
     def _test_kill(self, p, first_time, kill_exc_type):
@@ -254,7 +255,7 @@ class TestRaise_link(TestCase):
         p = self.p = proc.spawn(sleep, DELAY)
         self._test_kill(p, True, proc.LinkedKilled)
         # repeating the same with dead process
-        for _ in xrange(3):
+        for _ in six.moves.range(3):
             self._test_kill(p, False, proc.LinkedKilled)
 
 class TestRaise_link_exception(TestRaise_link):

--- a/tests/thread_test.py
+++ b/tests/thread_test.py
@@ -1,4 +1,6 @@
 import weakref
+import six
+
 from eventlet.green import thread
 from eventlet import greenthread
 from eventlet import event
@@ -102,7 +104,7 @@ class Locals(LimitedTestCase):
             my_local.foo = o
             
         p = eventlet.GreenPool()
-        for i in xrange(100):
+        for i in six.moves.range(100):
             p.spawn(do_something, i)
         p.waitall()
         del p

--- a/tests/tpool_test.py
+++ b/tests/tpool_test.py
@@ -20,6 +20,7 @@ from sys import stdout
 import time
 import re
 import gc
+import six
 from tests import skipped, skip_with_pyevent, LimitedTestCase, main
 
 from eventlet import tpool, debug
@@ -144,7 +145,7 @@ class TestTpool(LimitedTestCase):
     @skip_with_pyevent
     def test_wrap_iterator(self):
         self.reset_timeout(2)
-        prox = tpool.Proxy(xrange(10))
+        prox = tpool.Proxy(six.moves.range(10))
         result = []
         for i in prox:
             result.append(i)
@@ -155,13 +156,13 @@ class TestTpool(LimitedTestCase):
         self.reset_timeout(5)  # might take a while due to imprecise sleeping
         def foo():
             import time
-            for x in xrange(2):
+            for x in six.moves.range(2):
                 yield x
                 time.sleep(0.001)
 
         counter = [0]
         def tick():
-            for i in xrange(20000):
+            for i in six.moves.range(20000):
                 counter[0]+=1
                 if counter[0] % 20 == 0:
                     eventlet.sleep(0.0001)
@@ -296,7 +297,7 @@ class TpoolLongTests(LimitedTestCase):
         def sender_loop(loopnum):
             obj = tpool.Proxy(Dummy())
             count = 100
-            for n in xrange(count):
+            for n in six.moves.range(count):
                 eventlet.sleep(random.random()/200.0)
                 now = time.time()
                 token = loopnum * count + n
@@ -306,7 +307,7 @@ class TpoolLongTests(LimitedTestCase):
 
         cnt = 10
         pile = eventlet.GreenPile(cnt)
-        for i in xrange(cnt):
+        for i in six.moves.range(cnt):
             pile.spawn(sender_loop,i)
         results = list(pile)
         self.assertEquals(len(results), cnt)
@@ -339,14 +340,14 @@ from eventlet.tpool import execute
         tpool.execute(noop)  # get it started
         gc.collect()
         initial_objs = len(gc.get_objects())
-        for i in xrange(10):
+        for i in six.moves.range(10):
             self.assertRaises(RuntimeError, tpool.execute, raise_exception)
         gc.collect()
         middle_objs = len(gc.get_objects())
         # some objects will inevitably be created by the previous loop
         # now we test to ensure that running the loop an order of
         # magnitude more doesn't generate additional objects
-        for i in xrange(100):
+        for i in six.moves.range(100):
             self.assertRaises(RuntimeError, tpool.execute, raise_exception)
         first_created = middle_objs - initial_objs
         gc.collect()

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -1,5 +1,6 @@
 import socket
 import errno
+import six
 
 import eventlet
 from eventlet.green import urllib2
@@ -23,7 +24,7 @@ def handle(ws):
                 break
             ws.send(m)
     elif ws.path == '/range':
-        for i in xrange(10):
+        for i in six.moves.range(10):
             ws.send("msg %d" % i)
             eventlet.sleep(0.01)
     elif ws.path == '/error':

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ ignore = E261
 max-line-length = 101
 
 [tox]
-envlist = py26selects,py26poll,py26epolls,py27selects,py27poll,py27epolls
+envlist = py26selects,py26poll,py26epolls,py27selects,py27poll,py27epolls,py33selects,py33poll,py33epolls
 
 [testenv]
 downloadcache = {toxworkdir}/pip_download_cache
@@ -20,6 +20,7 @@ deps =
     pyopenssl==0.13
     MySQL-python==1.2.4
     psycopg2==2.5.1
+    six==1.4.1
 commands =
     nosetests --verbose tests/
     nosetests --verbose --with-doctest eventlet/coros.py eventlet/event.py \
@@ -63,6 +64,27 @@ deps =
 
 [testenv:py27epolls]
 basepython = python2.7
+setenv = EVENTLET_HUB = epolls
+deps =
+    {[testenv]deps}
+    pyzmq==13.1.0
+
+[testenv:py33selects]
+basepython = python3.3
+setenv = EVENTLET_HUB = selects
+deps =
+    {[testenv]deps}
+    pyzmq==13.1.0
+
+[testenv:py33poll]
+basepython = python3.3
+setenv = EVENTLET_HUB = poll
+deps =
+    {[testenv]deps}
+    pyzmq==13.1.0
+
+[testenv:py33epolls]
+basepython = python3.3
 setenv = EVENTLET_HUB = epolls
 deps =
     {[testenv]deps}


### PR DESCRIPTION
One step at a time. This changes all xrange to six.moves.range which is guaranteed to work on python 2 and python 3.
