### PR TITLE
Atfork

### DIFF
--- a/eventlet/__init__.py
+++ b/eventlet/__init__.py
@@ -2,6 +2,7 @@ version_info = (0, 15, 0, "dev")
 __version__ = ".".join(map(str, version_info))
 
 try:
+    from eventlet import atfork
     from eventlet import greenthread
     from eventlet import greenpool
     from eventlet import queue

--- a/eventlet/atfork.py
+++ b/eventlet/atfork.py
@@ -1,0 +1,18 @@
+import os
+
+
+_child_callbacks = []
+
+
+def register_child_callback(callback):
+    _child_callbacks.append(callback)
+
+
+__original_fork__ = os.fork
+def _patched_fork():
+    pid = __original_fork__()
+    if pid == 0:
+        for callback in _child_callbacks:
+            callback()
+    return pid
+os.fork = _patched_fork

--- a/eventlet/hubs/__init__.py
+++ b/eventlet/hubs/__init__.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import eventlet
 from eventlet.support import greenlets as greenlet
 from eventlet import patcher
 
@@ -158,3 +159,9 @@ def trampoline(fd, read=None, write=None, timeout=None,
     finally:
         if t is not None:
             t.cancel()
+
+
+def _del_hub():
+    if hasattr(_threadlocal, 'hub'):
+        del _threadlocal.hub
+eventlet.atfork.register_child_callback(_del_hub)

--- a/eventlet/hubs/epolls.py
+++ b/eventlet/hubs/epolls.py
@@ -46,15 +46,11 @@ class Hub(poll.Hub):
         oldlisteners = bool(self.listeners[READ].get(fileno) or
                             self.listeners[WRITE].get(fileno))
         listener = BaseHub.add(self, evtype, fileno, cb)
-        try:
-            if not oldlisteners:
-                # Means we've added a new listener
-                self.register(fileno, new=True)
-            else:
-                self.register(fileno, new=False)
-        except IOError, ex:    # ignore EEXIST, #80
-            if get_errno(ex) != errno.EEXIST:
-                raise
+        if not oldlisteners:
+            # Means we've added a new listener
+            self.register(fileno, new=True)
+        else:
+            self.register(fileno, new=False)
         return listener
 
     def do_poll(self, seconds):

--- a/eventlet/hubs/epolls.py
+++ b/eventlet/hubs/epolls.py
@@ -1,5 +1,3 @@
-import errno
-from eventlet.support import get_errno
 from eventlet import patcher
 time = patcher.original('time')
 select = patcher.original("select")

--- a/tests/hub_test.py
+++ b/tests/hub_test.py
@@ -293,41 +293,6 @@ class TestBadFilenos(LimitedTestCase):
         self.assertRaises(ValueError, select.select, [-1], [], [])
 
 
-class TestFork(ProcessBase):
-
-    @skip_with_pyevent
-    def test_fork(self):
-        new_mod = """
-import os
-import eventlet
-server = eventlet.listen(('localhost', 12345))
-t = eventlet.Timeout(0.01)
-try:
-    new_sock, address = server.accept()
-except eventlet.Timeout, t:
-    pass
-
-pid = os.fork()
-if not pid:
-    t = eventlet.Timeout(0.1)
-    try:
-        new_sock, address = server.accept()
-    except eventlet.Timeout, t:
-        print "accept blocked"
-
-else:
-    kpid, status = os.wait()
-    assert kpid == pid
-    assert status == 0
-    print "child died ok"
-"""
-        self.write_to_tempfile("newmod", new_mod)
-        output, lines = self.launch_subprocess('newmod.py')
-        self.assertEqual(len(lines), 3, output)
-        self.assert_("accept blocked" in lines[0])
-        self.assert_("child died ok" in lines[1])
-
-
 class TestDeadRunLoop(LimitedTestCase):
     TEST_TIMEOUT = 2
 


### PR DESCRIPTION
This fixes #80: https://bitbucket.org/eventlet/eventlet/issue/80/eexist-should-be-ignored-for-epoll. The issue is that a parent and child process can end up sharing an instance of epoll after a fork. Since file descriptors are unique only within a process, the two processes can end up with the same file descriptor pointing to two completely different resources. So the child registers socket A with FD 3 and the parent registers socket B with FD 3, and epoll gets messed up. These conflicts are likely because Linux will use the lowest free number for creating a new file descriptors.

We found this happening at Mixpanel in one of our services that's deployed using a prefork server. If some code causes the server process to create an eventlet hub prior to the fork, the master and workers all share the same epoll instance, and strange behavior ensues.

More generally, like threads, it doesn't make much sense to have a child process inherit its parent's state. Therefore, we decided to clean the parent's hub out of the child after fork. Any subsequent use of eventlet in the child will generate a new hub.
