### PR TITLE
PyPy 2.3 compatibility fix

### DIFF
--- a/eventlet/greenio.py
+++ b/eventlet/greenio.py
@@ -344,10 +344,10 @@ class GreenSocket(object):
 
     if "__pypy__" in sys.builtin_module_names:
         def _reuse(self):
-            self.fd._sock._reuse()
+            getattr(self.fd, '_sock', self.fd)._reuse()
 
         def _drop(self):
-            self.fd._sock._drop()
+            getattr(self.fd, '_sock', self.fd)._drop()
 
 
 class _SocketDuckForFd(object):


### PR DESCRIPTION
In PyPy 2.3 `socket.socket` has no `_sock` property which causes eventlet failures.

Instead the same functions accessible via `_sock` are available through `socket.socket` itself. This patch is capable of handling both cases, first looking for `_sock` object and then falling back on itself as default. 
