### PR TITLE
When we mark a socket as closed we still need to be able to close it

### DIFF
--- a/eventlet/greenio.py
+++ b/eventlet/greenio.py
@@ -201,19 +201,13 @@ class GreenSocket(object):
             self._trampoline(fd, read=True, timeout=self.gettimeout(),
                        timeout_exc=socket.timeout("timed out"))
 
-    def _defanged_close(self):
-        # Already closed the once
-        pass
-
-
     def _mark_as_closed(self):
         """ Mark this socket as being closed """
-        self.close = self._defanged_close
         self._closed = True
 
     def close(self):
         notify_close(self.fd)
-        self._mark_as_closed()   # Don't do this twice.
+        self._mark_as_closed()
         return self.fd.close()
 
     def __del__(self):
@@ -432,12 +426,7 @@ class _SocketDuckForFd(object):
             self._mark_as_closed()
             raise
 
-    def _defanged_close(self):
-        # Don't let anything close the wrong filehandle.
-        pass
-
     def _mark_as_closed(self):
-        self.close = self._close = self._defanged_close
         self._closed = True
 
     @property
@@ -568,14 +557,7 @@ class GreenPipe(_fileobject):
             self.mode,
             (id(self) < 0) and (sys.maxint + id(self)) or id(self))
 
-    def _defanged_close(self):
-        pass
-
-    def _mark_as_closed(self):
-        self.close = self._defanged_close
-
     def close(self):
-        self._mark_as_closed()
         super(GreenPipe, self).close()
         for method in [
                 'fileno', 'flush', 'isatty', 'next', 'read', 'readinto',


### PR DESCRIPTION
https://github.com/eventlet/eventlet/issues/122

After a long running job that highlighted a previous known issue with
Second Simultaneous Read issue I used http://mg.pov.lt/objgraph/ to print
out all the types and counts still referenced by the GC.

Before this patch I was seeing GreenSocket and _socketobject types been
referenced. Depending on how long I ran the test job for I saw more references
to these objects. After this patch I see no reference no matter how long I
run my test for.
