### PR TITLE
wsgi: Support optional headers w/ "100 Continue" responses

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -83,13 +83,33 @@ class Input(object):
         self.chunked_input = chunked_input
         self.chunk_length = -1
 
+        # (optional) headers to send with a 100-Continue response. Set by
+        # calling set_hundred_continue_respose_headers() on env['wsgi.input']
+        self.hundred_continue_headers = None
+        self.capitalize_response_headers = True
+
+    def _send_100_continue_response(self):
+        towrite = []
+
+        # 100 Continue status line
+        towrite.append(self.wfile_line)
+
+        # Optional headers
+        if self.hundred_continue_headers is not None:
+            # 100 Continue headers
+            for header in self.hundred_continue_headers:
+                towrite.append('%s: %s\r\n' % header)
+
+        # Blank line
+        towrite.append('\r\n')
+
+        self.wfile.writelines(towrite)
+        self.wfile = None
+        self.wfile_line = None
+
     def _do_read(self, reader, length=None):
         if self.wfile is not None:
-            # 100 Continue
-            self.wfile.write(self.wfile_line)
-            self.wfile = None
-            self.wfile_line = None
-
+            self._send_100_continue_response()
         if length is None and self.content_length is not None:
             length = self.content_length - self.position
         if length and length > self.content_length - self.position:
@@ -105,10 +125,7 @@ class Input(object):
 
     def _chunked_read(self, rfile, length=None, use_readline=False):
         if self.wfile is not None:
-            # 100 Continue
-            self.wfile.write(self.wfile_line)
-            self.wfile = None
-            self.wfile_line = None
+            self._send_100_continue_response()
         try:
             if length == 0:
                 return ""
@@ -174,6 +191,18 @@ class Input(object):
 
     def get_socket(self):
         return self.rfile._sock
+
+    def set_hundred_continue_response_headers(self, headers,
+                                              capitalize_response_headers=True):
+        # Response headers capitalization
+        # CONTent-TYpe: TExt/PlaiN -> Content-Type: TExt/PlaiN
+        # Per HTTP RFC standard, header name is case-insensitive.
+        # Please, fix your client to ignore header case if possible.
+        if capitalize_response_headers:
+            headers = [
+                ('-'.join([x.capitalize() for x in key.split('-')]), value)
+                for key, value in headers]
+        self.hundred_continue_headers = headers
 
 
 class HeaderLineTooLong(Exception):
@@ -349,6 +378,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
                     towrite.append('Connection: keep-alive\r\n')
                 towrite.append('\r\n')
                 # end of header writing
+                print towrite, data
 
             if use_chunked[0]:
                 # Write the chunked encoding
@@ -526,7 +556,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
 
         if env.get('HTTP_EXPECT') == '100-continue':
             wfile = self.wfile
-            wfile_line = 'HTTP/1.1 100 Continue\r\n\r\n'
+            wfile_line = 'HTTP/1.1 100 Continue\r\n'
         else:
             wfile = None
             wfile_line = None


### PR DESCRIPTION
Since WSGI is all about a single response to a single
request, in order for servers to process a PUT as a
single HTTP request and at the same time pass **hints**
back to the client (for example, a payload type that the
server can accept, or to inform the client that the server
expects to receive payload metadata at the end of the
payload transfer, etc), "100 Continue" response headers
is pretty much only place to add these hints.

This is consistent with **RFC2616, section 10.1**:

---

10.1 Informational 1xx

This class of status code indicates a provisional response,
consisting only of the **Status-Line** and **optional
## headers**, and is terminated by an empty line.

Openstack Swift has an immediate use case for this feature
where the object server will use an
"Accept-Payload-Footer: 1" like header to hint the proxy
server to send a payload footer after it has finished
transmitting the payload (for sending metadata for an
erasure coded or encrypted payload, enforcing end-to-end
Etag checks, etc).

Addresses eventlet enhancement #126

Signed-off-by: Tushar Gohad tushar.gohad@intel.com
