### PR TITLE
Fix string concatenation errors

### DIFF
--- a/eventlet/green/select.py
+++ b/eventlet/green/select.py
@@ -17,12 +17,12 @@ def get_fileno(obj):
         f = obj.fileno
     except AttributeError:
         if not isinstance(obj, six.integer_types):
-            raise TypeError("Expected int or long, got " + type(obj))
+            raise TypeError("Expected int or long, got %s" % type(obj))
         return obj
     else:
         rv = f()
         if not isinstance(rv, six.integer_types):
-            raise TypeError("Expected int or long, got " + type(rv))
+            raise TypeError("Expected int or long, got %s" % type(rv))
         return rv
 
 

--- a/eventlet/hubs/twistedr.py
+++ b/eventlet/hubs/twistedr.py
@@ -36,7 +36,7 @@ def callLater(DelayedCallClass, reactor, _seconds, _f, *args, **kw):
     # the same as original but creates fixed DelayedCall instance
     assert callable(_f), "%s is not callable" % _f
     if not isinstance(_seconds, (int, long, float)):
-        raise TypeError("Seconds must be int, long, or float, was " + type(_seconds))
+        raise TypeError("Seconds must be int, long, or float, was %s" % type(_seconds))
     assert sys.maxint >= _seconds >= 0, \
         "%s is not greater than or equal to 0 seconds" % (_seconds,)
     tple = DelayedCallClass(reactor.seconds() + _seconds, _f, args, kw,

--- a/tests/greenio_test.py
+++ b/tests/greenio_test.py
@@ -8,6 +8,7 @@ import shutil
 import socket as _orig_sock
 import sys
 import tempfile
+from unittest import TestCase
 
 from eventlet import event, greenio, debug
 from eventlet.hubs import get_hub
@@ -609,6 +610,38 @@ class TestGreenSocket(LimitedTestCase):
         s1, s2 = socket.socketpair()
         assert select.select([], [s1], [], 0) == ([], [s1], [])
         assert select.select([], [s1], [], 0) == ([], [s1], [])
+
+
+class TestGreenSelect(TestCase):
+    def test_get_fileno(self):
+        class DummySocket(object):
+            def fileno(self):
+                return 123
+        self.assertEqual(123, select.get_fileno(DummySocket()))
+
+    def test_get_fileno_int(self):
+        self.assertEqual(123, select.get_fileno(123))
+
+    def test_get_fileno_typ_error1(self):
+        try:
+            select.get_fileno('foo')
+        except TypeError as ex:
+            expected = 'Expected int or long, got <type \'str\'>'
+            self.assertEqual(expected, str(ex))
+        else:
+            self.fail('Expected TypeError not raised')
+
+    def test_get_fileno_type_error2(self):
+        class DummySocket(object):
+            def fileno(self):
+                return 'foo'
+        try:
+            select.get_fileno(DummySocket())
+        except TypeError as ex:
+            expected = 'Expected int or long, got <type \'str\'>'
+            self.assertEqual(expected, str(ex))
+        else:
+            self.fail('Expected TypeError not raised')
 
 
 class TestGreenPipe(LimitedTestCase):


### PR DESCRIPTION
Some error paths concatenate the output of "type" with a string,
which gives TypeError: cannot concatenate 'str' and 'type' objects,
rather than describing the actual error.

Note the test is somewhat limited because the assertRaises doesn't return the exception, unlike e.g with testools.TestCase.

Closes #149
