### PR TITLE
Python 3 compat; Improve WSGI, WS, threading and tests

### DIFF
--- a/eventlet/green/thread.py
+++ b/eventlet/green/thread.py
@@ -1,6 +1,6 @@
 """Implements the standard thread module, using greenthreads."""
 from eventlet.support.six.moves import _thread as __thread
-from eventlet.support import greenlets as greenlet
+from eventlet.support import greenlets as greenlet, six
 from eventlet import greenthread
 from eventlet.semaphore import Semaphore as LockType
 
@@ -11,6 +11,16 @@ __patched__ = ['get_ident', 'start_new_thread', 'start_new', 'allocate_lock',
 
 error = __thread.error
 __threadcount = 0
+
+
+if six.PY3:
+    def _set_sentinel():
+        # HACK this is dummy code
+        # TODO possibly reimplement this:
+        # https://hg.python.org/cpython/file/b5e9bc4352e1/Modules/_threadmodule.c#l1203
+        return allocate_lock()
+
+    TIMEOUT_MAX = __thread.TIMEOUT_MAX
 
 
 def _count():

--- a/eventlet/green/threading.py
+++ b/eventlet/green/threading.py
@@ -2,11 +2,16 @@
 from eventlet import patcher
 from eventlet.green import thread
 from eventlet.green import time
-from eventlet.support import greenlets as greenlet
+from eventlet.support import greenlets as greenlet, six
 
-__patched__ = ['_start_new_thread', '_allocate_lock', '_get_ident', '_sleep',
-               'local', 'stack_size', 'Lock', 'currentThread',
+__patched__ = ['_start_new_thread', '_allocate_lock',
+               '_sleep', 'local', 'stack_size', 'Lock', 'currentThread',
                'current_thread', '_after_fork', '_shutdown']
+
+if six.PY2:
+    __patched__ += ['_get_ident']
+else:
+    __patched__ += ['get_ident', '_set_sentinel']
 
 __orig_threading = patcher.original('threading')
 __threadlocal = __orig_threading.local()
@@ -15,7 +20,7 @@ __threadlocal = __orig_threading.local()
 patcher.inject(
     'threading',
     globals(),
-    ('thread', thread),
+    ('thread' if six.PY2 else '_thread', thread),
     ('time', time))
 
 del patcher

--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -168,25 +168,24 @@ class WebSocketWSGI(object):
         if qs is not None:
             location += '?' + qs
         if self.protocol_version == 75:
-            handshake_reply = ("HTTP/1.1 101 Web Socket Protocol Handshake\r\n"
-                               "Upgrade: WebSocket\r\n"
-                               "Connection: Upgrade\r\n"
-                               "WebSocket-Origin: %s\r\n"
-                               "WebSocket-Location: %s\r\n\r\n" % (
-                                   environ.get('HTTP_ORIGIN'),
-                                   location))
+            handshake_reply = (
+                b"HTTP/1.1 101 Web Socket Protocol Handshake\r\n"
+                b"Upgrade: WebSocket\r\n"
+                b"Connection: Upgrade\r\n"
+                b"WebSocket-Origin: " + environ.get('HTTP_ORIGIN') + b"\r\n"
+                b"WebSocket-Location: " + six.b(location) + b"\r\n\r\n"
+            )
         elif self.protocol_version == 76:
-            handshake_reply = ("HTTP/1.1 101 WebSocket Protocol Handshake\r\n"
-                               "Upgrade: WebSocket\r\n"
-                               "Connection: Upgrade\r\n"
-                               "Sec-WebSocket-Origin: %s\r\n"
-                               "Sec-WebSocket-Protocol: %s\r\n"
-                               "Sec-WebSocket-Location: %s\r\n"
-                               "\r\n%s" % (
-                                   environ.get('HTTP_ORIGIN'),
-                                   environ.get('HTTP_SEC_WEBSOCKET_PROTOCOL', 'default'),
-                                   location,
-                                   response))
+            handshake_reply = (
+                b"HTTP/1.1 101 WebSocket Protocol Handshake\r\n"
+                b"Upgrade: WebSocket\r\n"
+                b"Connection: Upgrade\r\n"
+                b"Sec-WebSocket-Origin: " + six.b(environ.get('HTTP_ORIGIN')) + b"\r\n"
+                b"Sec-WebSocket-Protocol: " +
+                six.b(environ.get('HTTP_SEC_WEBSOCKET_PROTOCOL', 'default')) + b"\r\n"
+                b"Sec-WebSocket-Location: " + six.b(location) + b"\r\n"
+                b"\r\n" + response
+            )
         else:  # pragma NO COVER
             raise ValueError("Unknown WebSocket protocol version.")
         sock.sendall(handshake_reply)
@@ -244,7 +243,7 @@ class WebSocketWSGI(object):
                 out += char
             elif char == " ":
                 spaces += 1
-        return int(out) / spaces
+        return int(out) // spaces
 
 
 class WebSocket(object):
@@ -281,7 +280,7 @@ class WebSocket(object):
         self.environ = environ
         self.version = version
         self.websocket_closed = False
-        self._buf = ""
+        self._buf = b""
         self._msgs = collections.deque()
         self._sendlock = semaphore.Semaphore()
 
@@ -294,8 +293,8 @@ class WebSocket(object):
         if isinstance(message, six.text_type):
             message = message.encode('utf-8')
         elif not isinstance(message, six.binary_type):
-            message = b'%s' % (message,)
-        packed = b"\x00%s\xFF" % message
+            message = six.b(str(message))
+        packed = b"\x00" + message + b"\xFF"
         return packed
 
     def _parse_messages(self):
@@ -309,17 +308,17 @@ class WebSocket(object):
         end_idx = 0
         buf = self._buf
         while buf:
-            frame_type = ord(buf[0])
+            frame_type = six.indexbytes(buf, 0)
             if frame_type == 0:
                 # Normal message.
-                end_idx = buf.find("\xFF")
+                end_idx = buf.find(b"\xFF")
                 if end_idx == -1:  # pragma NO COVER
                     break
                 msgs.append(buf[1:end_idx].decode('utf-8', 'replace'))
                 buf = buf[end_idx + 1:]
             elif frame_type == 255:
                 # Closing handshake.
-                assert ord(buf[1]) == 0, "Unexpected closing handshake: %r" % buf
+                assert six.indexbytes(buf, 1) == 0, "Unexpected closing handshake: %r" % buf
                 self.websocket_closed = True
                 break
             else:
@@ -355,7 +354,7 @@ class WebSocket(object):
                 return None
             # no parsed messages, must mean buf needs more data
             delta = self.socket.recv(8096)
-            if delta == '':
+            if delta == b'':
                 return None
             self._buf += delta
             msgs = self._parse_messages()

--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -69,11 +69,13 @@ class Input(object):
     def __init__(self,
                  rfile,
                  content_length,
+                 sock,
                  wfile=None,
                  wfile_line=None,
                  chunked_input=False):
 
         self.rfile = rfile
+        self._sock = sock
         if content_length is not None:
             content_length = int(content_length)
         self.content_length = content_length
@@ -193,7 +195,7 @@ class Input(object):
         return iter(self.read, b'')
 
     def get_socket(self):
-        return self.rfile._sock
+        return self._sock
 
     def set_hundred_continue_response_headers(self, headers,
                                               capitalize_response_headers=True):
@@ -387,24 +389,8 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
                 towrite.append(six.b("%x" % (len(data),)) + b"\r\n" + data + b"\r\n")
             else:
                 towrite.append(data)
-            try:
-                _writelines(towrite)
-                length[0] = length[0] + sum(map(len, towrite))
-            except UnicodeEncodeError:
-                self.server.log_message(
-                    "Encountered non-ascii unicode while attempting to write"
-                    "wsgi response: %r" %
-                    [x for x in towrite if isinstance(x, six.text_type)])
-                self.server.log_message(traceback.format_exc())
-                _writelines(
-                    ["HTTP/1.1 500 Internal Server Error\r\n",
-                     "Connection: close\r\n",
-                     "Content-type: text/plain\r\n",
-                     "Content-length: 98\r\n",
-                     "Date: %s\r\n" % format_date_time(time.time()),
-                     "\r\n",
-                     ("Internal Server Error: wsgi application passed "
-                      "a unicode object to the server instead of a string.")])
+            _writelines(towrite)
+            length[0] = length[0] + sum(map(len, towrite))
 
         def start_response(status, response_headers, exc_info=None):
             status_code[0] = status.split()[0]
@@ -448,6 +434,8 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
                 minimum_write_chunk_size = int(self.environ.get(
                     'eventlet.minimum_write_chunk_size', self.minimum_chunk_size))
                 for data in result:
+                    if not isinstance(data, six.binary_type):
+                        raise Exception('The result iterable has to return bytestrings')
                     towrite.append(data)
                     towrite_size += len(data)
                     if towrite_size >= minimum_write_chunk_size:
@@ -464,7 +452,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
                 self.close_connection = 1
                 tb = traceback.format_exc()
                 self.server.log_message(tb)
-                if not headers_set:
+                if not headers_sent:
                     err_body =six.b(tb) if self.server.debug else b''
                     start_response("500 Internal Server Error",
                                    [('Content-type', 'text/plain'),
@@ -564,7 +552,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
             wfile_line = None
         chunked = env.get('HTTP_TRANSFER_ENCODING', '').lower() == 'chunked'
         env['wsgi.input'] = env['eventlet.input'] = Input(
-            self.rfile, length, wfile=wfile, wfile_line=wfile_line,
+            self.rfile, length, self.connection, wfile=wfile, wfile_line=wfile_line,
             chunked_input=chunked)
         env['eventlet.posthooks'] = []
 

--- a/tests/greenio_test.py
+++ b/tests/greenio_test.py
@@ -273,7 +273,7 @@ class TestGreenSocket(LimitedTestCase):
             # by closing the socket prior to using the made file
             try:
                 conn, addr = listener.accept()
-                fd = conn.makefile('w')
+                fd = conn.makefile('wb')
                 conn.close()
                 fd.write(b'hello\n')
                 fd.close()
@@ -287,7 +287,7 @@ class TestGreenSocket(LimitedTestCase):
             # by closing the made file and then sending a character
             try:
                 conn, addr = listener.accept()
-                fd = conn.makefile('w')
+                fd = conn.makefile('wb')
                 fd.write(b'hello')
                 fd.close()
                 conn.send(b'\n')
@@ -300,7 +300,7 @@ class TestGreenSocket(LimitedTestCase):
         def did_it_work(server):
             client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             client.connect(('127.0.0.1', server.getsockname()[1]))
-            fd = client.makefile()
+            fd = client.makefile('rb')
             client.close()
             assert fd.readline() == b'hello\n'
             assert fd.read() == b''
@@ -329,7 +329,7 @@ class TestGreenSocket(LimitedTestCase):
             # closing the file object should close everything
             try:
                 conn, addr = listener.accept()
-                conn = conn.makefile('w')
+                conn = conn.makefile('wb')
                 conn.write(b'hello\n')
                 conn.close()
                 gc.collect()
@@ -344,7 +344,7 @@ class TestGreenSocket(LimitedTestCase):
         killer = eventlet.spawn(accept_once, server)
         client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         client.connect(('127.0.0.1', server.getsockname()[1]))
-        fd = client.makefile()
+        fd = client.makefile('rb')
         client.close()
         assert fd.read() == b'hello\n'
         assert fd.read() == b''
@@ -603,7 +603,7 @@ class TestGreenSocket(LimitedTestCase):
     def test_sockopt_interface(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         assert sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR) == 0
-        assert sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1) == '\000'
+        assert sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1) == b'\000'
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
     def test_socketpair_select(self):

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -145,6 +145,17 @@ hello world
 """
 
 
+def recvall(socket_):
+    result = b''
+    while True:
+        chunk = socket_.recv()
+        result += chunk
+        if chunk == b'':
+            break
+
+    return result
+
+
 class ConnectionClosed(Exception):
     pass
 
@@ -449,8 +460,8 @@ class TestHttpd(_TestBase):
         sock.write(
             b'POST /foo HTTP/1.1\r\nHost: localhost\r\n'
             b'Connection: close\r\nContent-length:3\r\n\r\nabc')
-        result = sock.read(8192)
-        self.assertEqual(result[-3:], b'abc')
+        result = recvall(sock)
+        assert result.endswith(b'abc')
 
     @tests.skip_if_no_ssl
     def test_013_empty_return(self):
@@ -469,8 +480,8 @@ class TestHttpd(_TestBase):
         sock = eventlet.connect(('localhost', server_sock.getsockname()[1]))
         sock = eventlet.wrap_ssl(sock)
         sock.write(b'GET /foo HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n')
-        result = sock.read(8192)
-        self.assertEqual(result[-4:], b'\r\n\r\n')
+        result = recvall(sock)
+        assert result[-4:] == b'\r\n\r\n'
 
     def test_014_chunked_post(self):
         self.site.application = chunked_post
@@ -964,9 +975,9 @@ class TestHttpd(_TestBase):
             try:
                 client = ssl.wrap_socket(eventlet.connect(('localhost', port)))
                 client.write(b'GET / HTTP/1.0\r\nHost: localhost\r\n\r\n')
-                result = client.read()
-                assert result.startswith('HTTP'), result
-                assert result.endswith('hello world')
+                result = recvall(client)
+                assert result.startswith(b'HTTP'), result
+                assert result.endswith(b'hello world')
             except ImportError:
                 pass  # TODO(openssl): should test with OpenSSL
             greenthread.kill(g)
@@ -1163,8 +1174,8 @@ class TestHttpd(_TestBase):
     def test_unicode_raises_error(self):
         def wsgi_app(environ, start_response):
             start_response("200 OK", [])
-            yield u"oh hai"
-            yield u"non-encodable unicode: \u0230"
+            yield b"oh hai"
+            yield u"any unicode string should raise an error"
         self.site.application = wsgi_app
         sock = eventlet.connect(('localhost', self.port))
         fd = sock.makefile('rwb')
@@ -1173,7 +1184,7 @@ class TestHttpd(_TestBase):
         result = read_http(sock)
         self.assertEqual(result.status, 'HTTP/1.1 500 Internal Server Error')
         self.assertEqual(result.headers_lower['connection'], 'close')
-        assert b'unicode' in result.body
+        assert b'bytestring' in result.body
 
     def test_path_info_decoding(self):
         def wsgi_app(environ, start_response):


### PR DESCRIPTION
This includes:
- patching more tests to pass
- removing few unit tests which I think are redundant
- repeating SSL socket reads in a loop to read all data (I suspect this
  is related to the fact that writelines is used in the server code
  there and Python 3 writelines calls write/send repeatedly while on
  Python 2 it calls it once; on one hand there's no guarantee that
  single recv/read will return all data sent by the server, on the other
  hand it's quite suspicious that the number of required reads seems to
  be connected to the number of sends on the other side of the
  connection)
- working through Python 2/Python 3 threading and thread differences;
  the lock code I used is the simplest way I could make the tests
  pass but will likely need to be modified in order to match the
  original

This commit includes 6bcb1dc3686f72b0f1af803b46883ce4f5e4b8df and closes
GH #153 

@temoto please QA - the thing that bugs me the most is this place which, after quick look at the rest of the code, seems like a typo and the change doesn't break Python 2 build but I think I'll have a longer read when I have a moment: https://github.com/eventlet/eventlet/commit/01093df590b12cc0ee6aa46c2aaf87458cf3ce78#diff-351c1d7948db1b3567d6da5f75800f81R455
