### PR TITLE
Fix TimeoutExpired class

### DIFF
--- a/eventlet/green/subprocess.py
+++ b/eventlet/green/subprocess.py
@@ -21,8 +21,9 @@ if getattr(subprocess_orig, 'TimeoutExpired', None) is None:
         a child process.
         """
 
-        def __init__(self, timeout, cmd, output=None):
+        def __init__(self, cmd, timeout, output=None):
             self.cmd = cmd
+            self.timeout = timeout
             self.output = output
 
         def __str__(self):

--- a/tests/subprocess_test.py
+++ b/tests/subprocess_test.py
@@ -12,13 +12,16 @@ def test_subprocess_wait():
     # In Python 3.3 subprocess.Popen.wait() method acquired `timeout`
     # argument.
     # RHEL backported it to their Python 2.6 package.
-    p = subprocess.Popen(
-        [sys.executable, "-c", "import time; time.sleep(0.5)"])
+    cmd = [sys.executable, "-c", "import time; time.sleep(0.5)"]
+    p = subprocess.Popen(cmd)
     ok = False
     t1 = time.time()
     try:
         p.wait(timeout=0.1)
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as e:
+        str(e)  # make sure it doesnt throw
+        assert e.cmd == cmd
+        assert e.timeout == 0.1
         ok = True
     tdiff = time.time() - t1
     assert ok, 'did not raise subprocess.TimeoutExpired'


### PR DESCRIPTION
This pull requests fixes two issues:
1. Fix `__str__` method

This method was throwing an exception (`AttributeError: 'TimeoutExpired' object has no attribute 'timeout'
`) because it was referencing variable `timeout` which was never assigned in the constructor.
1. Fix argument order in the `TimeoutExpired` class constructor method

The line of code which was throwing this exception was passing arguments to the constructor in the same correct order which is used in Python 3.3 and above (`cmd, timeout, output`), but the constructor declared them in an invalid / different order (`timeout, cmd, output`).

See https://github.com/python/cpython/blob/master/Lib/subprocess.py#L388 for reference.
