### PR TITLE
enhance socketpair code in tpool

### DIFF
--- a/eventlet/tpool.py
+++ b/eventlet/tpool.py
@@ -256,12 +256,23 @@ def setup():
     else:
         _setup_already = True
 
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(('', 0))
-    sock.listen(1)
-    csock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    csock.connect(sock.getsockname())
-    _wsock, _addr = sock.accept()
+    if hasattr(socket, 'socketpair'):
+        csock, _wsock = socket.socketpair()
+    else:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind(('127.0.0.1', 0))
+            sock.listen(1)
+            csock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                csock.connect(sock.getsockname())
+                _wsock, _addr = sock.accept()
+            except:
+                csock.close()
+                raise
+        finally:
+            sock.close()
+
     _rsock = greenio.GreenSocket(csock)
 
     _reqq = Queue(maxsize=-1)


### PR DESCRIPTION
tpool.setup() uses its own implementation of socket.socketpair().

The "sock" socket is not explicitly closed, which emits a
ResourceWarning with Python 3 when warnings are enabled (ex: python3
-Wd).

This change uses socket.socketpair() if available (which is now the case
an all platforms since Python 3.5). It also ensures that the "sock"
socket is closed, and that all sockets are closed in case of error.

My code is based on the new socket.socketpair() implementation for
Windows in Python 3.5.
