### PR TITLE
Fix monkey-patched os.open(): add dir_fd parameter

### DIFF
--- a/eventlet/green/os.py
+++ b/eventlet/green/os.py
@@ -98,11 +98,14 @@ def waitpid(pid, options):
 __original_open__ = os_orig.open
 
 
-def open(file, flags, mode=0o777):
+def open(file, flags, mode=0o777, dir_fd=None):
     """ Wrap os.open
         This behaves identically, but collaborates with
         the hub's notify_opened protocol.
     """
-    fd = __original_open__(file, flags, mode)
+    if dir_fd is not None:
+        fd = __original_open__(file, flags, mode, dir_fd=dir_fd)
+    else:
+        fd = __original_open__(file, flags, mode)
     hubs.notify_opened(fd)
     return fd


### PR DESCRIPTION
The os.open() function got a new option keyword-only dir_fd parameter in
Python 3.3:
https://docs.python.org/3/library/os.html#os.open

With this change, the open() now accepts the dir_fd parameter.

For example, the dir_fd parameter is used by shutil.rmtree() for safety:
https://docs.python.org/3/library/shutil.html#shutil.rmtree
"Changed in version 3.3: Added a symlink attack resistant version that is used automatically if platform supports fd-based functions."
