### PR TITLE
Fix timers not cleaned up on MySQL test skips

### DIFF
--- a/tests/mysqldb_test.py
+++ b/tests/mysqldb_test.py
@@ -42,8 +42,6 @@ def mysql_requirement(_f):
 
 class TestMySQLdb(LimitedTestCase):
     def setUp(self):
-        super(TestMySQLdb, self).setUp()
-
         self._auth = get_database_auth()['MySQLdb']
         self.create_db()
         self.connection = None
@@ -55,6 +53,8 @@ class TestMySQLdb(LimitedTestCase):
         );""")
         self.connection.commit()
         cursor.close()
+
+        super(TestMySQLdb, self).setUp()
 
     def tearDown(self):
         if self.connection:


### PR DESCRIPTION
If it's determined that a MySQL test should be skipped during setUp(),
but after the parent setUp() has been called, having created and
started a timer, then tearDown() is never called and the timer never
cancelled, but left to expire during some future, unrelated test.

Move call to parent setUp() to end of child setUp() to insure that the
timer is only created and started after it's been determined that the
test shouldn't be skipped (ie create_db()).
