### PR TITLE
Make sure SSL retries are done using the exact same data buffer

### DIFF
--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -162,11 +162,14 @@ class GreenSSLSocket(_original_sslsocket):
                     self.__class__)
             amount = len(data)
             count = 0
+            data_to_send = data
             while (count < amount):
-                v = self.send(data[count:])
+                v = self.send(data_to_send)
                 count += v
                 if v == 0:
                     trampoline(self, write=True, timeout_exc=timeout_exc('timed out'))
+                else:
+                    data_to_send = data[count:]
             return amount
         else:
             while True:


### PR DESCRIPTION
This is a fix for the bug described in https://github.com/eventlet/eventlet/issues/114

OpenSSL requires that read/write retries are made using the exact same buffer.
When using `v = self.send(data[count:])` over multiple retries, the buffer is recreated - and OpenSSL detects it as a bad retry.