### PR TITLE
Fix exception raising in create_connection()

### DIFF
--- a/eventlet/green/socket.py
+++ b/eventlet/green/socket.py
@@ -53,9 +53,9 @@ def create_connection(address,
             sock.connect(sa)
             return sock
 
-        except error:
+        except error as e:
             if sock is not None:
                 sock.close()
-            raise
+            raise e
 
     raise error(msg)

--- a/eventlet/green/socket.py
+++ b/eventlet/green/socket.py
@@ -53,9 +53,9 @@ def create_connection(address,
             sock.connect(sa)
             return sock
 
-        except error as e:
-            msg = e
+        except error:
             if sock is not None:
                 sock.close()
+            raise
 
     raise error(msg)

--- a/tests/test__socket_errors.py
+++ b/tests/test__socket_errors.py
@@ -52,5 +52,13 @@ class TestSocketErrors(unittest.TestCase):
             cs.close()
             server.close()
 
+    def test_create_connection_refused(self):
+        try:
+            s = socket.create_connection(('localhost', 0))
+            self.fail("Shouldn't have connected")
+        except socket.error as ex:
+            assert ex.errno in [111, 61, 10061]
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -41,6 +41,7 @@ class TestWebSocket(_TestBase):
         self.site = wsapp
 
     def test_incorrect_headers(self):
+        print('DEBUGDMC: here')
         http = httplib.HTTPConnection('localhost', self.port)
         http.request("GET", "/echo")
         response = http.getresponse()


### PR DESCRIPTION
The create_connection() function could raise a
socket.error instance, where the errno was the actual
socket.error instance.

Fixes https://bitbucket.org/eventlet/eventlet/issue/168/create_connection-incorrectly-raises