### PR TITLE
Disable the thread state lock

### DIFF
--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -304,6 +304,13 @@ def monkey_patch(**on):
         # importlib must use real thread locks, not eventlet.Semaphore
         importlib._bootstrap._thread = thread
 
+        # Issue #185: Since Python 3.3, threading.RLock is implemented in C and
+        # so call a C function to get the thread identifier, instead of calling
+        # threading.get_ident(). Force the Python implementation of RLock which
+        # calls threading.get_ident() and so is compatible with eventlet.
+        import threading
+        threading.RLock = threading._PyRLock
+
 
 def is_monkey_patched(module):
     """Returns True if the given module is monkeypatched currently, False if

--- a/eventlet/semaphore.py
+++ b/eventlet/semaphore.py
@@ -78,9 +78,18 @@ class Semaphore(object):
         When invoked with blocking set to false, do not block. If a call without
         an argument would block, return false immediately; otherwise, do the
         same thing as when called without arguments, and return true.
+
+        Timeout value must be strictly positive.
         """
-        if not blocking and timeout is not None:
-            raise ValueError("can't specify timeout for non-blocking acquire")
+        if timeout == -1:
+            timeout = None
+        if timeout is not None and timeout < 0:
+            raise ValueError("timeout value must be strictly positive")
+        if not blocking:
+            if timeout is not None:
+                raise ValueError("can't specify timeout "
+                                 "for non-blocking acquire")
+            timeout = 0
         if not blocking and self.locked():
             return False
 

--- a/tests/isolated/patcher_threading_condition.py
+++ b/tests/isolated/patcher_threading_condition.py
@@ -1,0 +1,23 @@
+# Issue #185: test threading.Condition with monkey-patching
+import eventlet
+
+# no standard tests in this file, ignore
+__test__ = False
+
+
+if __name__ == '__main__':
+    eventlet.monkey_patch()
+
+    import threading
+
+    def func(c):
+        with c:
+            c.notify()
+
+    c = threading.Condition()
+    with c:
+        t = threading.Thread(target=func, args=(c,))
+        t.start()
+        c.wait()
+
+    print('pass')

--- a/tests/patcher_test.py
+++ b/tests/patcher_test.py
@@ -498,3 +498,7 @@ t2.join()
 
 def test_importlib_lock():
     tests.run_isolated('patcher_importlib_lock.py')
+
+
+def test_threading_condition():
+    tests.run_isolated('patcher_threading_condition.py')


### PR DESCRIPTION
This change fixes the threading support on Python 3.4 when eventlet is used with monkey-patching.

Python 3.4 introduces threading.Thread._tstate_lock to fix a race condition, see:
- https://hg.python.org/cpython/rev/d52b68edbca6
- http://bugs.python.org/issue18808

I'm not really proud of this change: patching a Thread instance after its creation is not the most elegant fix.

I tried to create a Thread subclass in eventlet.green.threading, but I got a lot of new issues. If the subclass is declared in eventlet.green.threading, the parent Thread class uses functions of the original threading module, instead of using patched functions by eventlet. It's unclear to me how symbols are added and patched in modules. I noticed that the threading module of the standard library is imported multiple times. The implementation of monkey-patching is really complex :-/

Currently, the best solution is to patch Thread instance in the patched thread.start_new_thread() function. The problem is to retrieve the instance. My heuristic checks if the wrapped function is the bounded Thread.run() method, and I retrieve the instance from function.__self__.

I'm not yet sure that I really understood the problem. At least, "tox -e py34-selects" pass.