### PR TITLE
greenpool: Make sure that imap/starmap set the correct pool

### DIFF
--- a/eventlet/greenpool.py
+++ b/eventlet/greenpool.py
@@ -150,7 +150,7 @@ class GreenPool(object):
         """
         if function is None:
             function = lambda *a: a
-        gi = GreenMap(self.size)
+        gi = GreenMap(self)
         greenthread.spawn_n(self._do_map, function, iterable, gi)
         return gi
 

--- a/tests/greenpool_test.py
+++ b/tests/greenpool_test.py
@@ -323,6 +323,12 @@ class GreenPool(tests.LimitedTestCase):
         p = greenpool.GreenPool()
         p.waitall()
 
+    def test_imap_sets_pool(self):
+        p = greenpool.GreenPool(4)
+        pile = p.imap(passthru, list(range(10)))
+        self.assertTrue(p is pile.pool)
+        p.waitall()
+
     def test_recursive_waitall(self):
         p = greenpool.GreenPool()
         gt = p.spawn(p.waitall)


### PR DESCRIPTION
Calling a GreenPool.imap() followed by a GreenPool.waitall() does not in fact
wait on the threads that were spawned, this is because we create a
completely new GreanPool instance for the resulting GreenPile result.

We really want to be spawning threads limited by the GreenPool instance
we call the imap() on, so we should be using it for the resulting GreenPile.