### PR TITLE
Issue #223: Fix threading monkey-patching on py3.4

### DIFF
--- a/tests/isolated/patcher_threading_join.py
+++ b/tests/isolated/patcher_threading_join.py
@@ -1,0 +1,23 @@
+# Issue #223: test threading.Thread.join with monkey-patching
+import eventlet
+
+# no standard tests in this file, ignore
+__test__ = False
+
+
+if __name__ == '__main__':
+    eventlet.monkey_patch()
+
+    import threading
+    import time
+
+    sleeper = threading.Thread(target=time.sleep, args=(1,))
+    start = time.time()
+    sleeper.start()
+    sleeper.join()
+    dt = time.time() - start
+
+    if dt < 1.0:
+        raise Exception("test failed: dt=%s" % dt)
+
+    print('pass')

--- a/tests/patcher_test.py
+++ b/tests/patcher_test.py
@@ -502,3 +502,7 @@ def test_importlib_lock():
 
 def test_threading_condition():
     tests.run_isolated('patcher_threading_condition.py')
+
+
+def test_threading_join():
+    tests.run_isolated('patcher_threading_join.py')


### PR DESCRIPTION
Fix the monkey-patching of the threading module on Python 3.4. Instead
of removing the thread state lock, patch the _bootstrap_inner() method
to release it.