### PR TITLE
tox 1.8 or newer is required

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ show-source = 1
 statistics = 1
 
 [tox]
+minversion=1.8
 envlist =
     pep8, py{26,27,33,34,py}-{selects,poll,epolls}, py{27,34,py}-dns
 


### PR DESCRIPTION
The "py{27,34,py}-dns" syntax in envlist is only supported on tox 1.8 or
newer.