### PR TITLE
Issue #226: HTTPS: Fix empty SSL certificate issue

### DIFF
--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -358,9 +358,14 @@ if hasattr(__ssl, 'sslwrap_simple'):
 
 if hasattr(__ssl, 'SSLContext'):
     @functools.wraps(__ssl.SSLContext.wrap_socket)
-    def _green_sslcontext_wrap_socket(self, sock, *a, **kw):
-        return GreenSSLSocket(sock, *a, **kw)
-
+    def _green_sslcontext_wrap_socket(self, sock, server_side=False,
+                                      do_handshake_on_connect=True,
+                                      suppress_ragged_eofs=True,
+                                      server_hostname=None):
+        return GreenSSLSocket(sock, server_side=server_side,
+                              do_handshake_on_connect=do_handshake_on_connect,
+                              suppress_ragged_eofs=suppress_ragged_eofs,
+                              server_hostname=server_hostname, _context=self)
     # FIXME:
     # * GreenSSLContext akin to GreenSSLSocket
     # * make ssl.create_default_context() use modified SSLContext from globals as usual


### PR DESCRIPTION
On python 3 and python 2.7.9, the requests library would raise the
following value error:

 ValueError: empty or no certificate, match_hostname needs
 a SSL socket or SSL context with either CERT_OPTIONAL or CERT_REQUIRED