### PR TITLE
Issue #192:Fix inifinte loop when connection lost

### DIFF
--- a/eventlet/greenio/base.py
+++ b/eventlet/greenio/base.py
@@ -360,6 +360,8 @@ class GreenSocket(object):
             except socket.error as e:
                 if get_errno(e) not in SOCKET_BLOCKING:
                     raise
+                elif get_errno(e) is errno.ENOTCONN:
+                    raise
 
             if total_sent == len_data:
                 break


### PR DESCRIPTION
when "Transport endpoint is not connected" error occurs on send function
it can be catched by except statement but skipped by if statement (because SOCKET_BLOCKING has ENOTCONN)
so comes infinite loop, then hang.
I worried about regression if i remove errno.ENOTCONN on SOCKET_BLOCKING
then I added new line for checking ENOTCONN