### PR TITLE
Greenfileio readall

### DIFF
--- a/eventlet/greenio/py3.py
+++ b/eventlet/greenio/py3.py
@@ -75,13 +75,13 @@ class GreenFileIO(_OriginalIOBase):
     def fileno(self):
         return self._fileno
 
-    def read(self, buflen=-1):
-        if buflen == -1:
+    def read(self, size=-1):
+        if size == -1:
             return self.readall()
 
         while True:
             try:
-                return _original_os.read(self._fileno, buflen)
+                return _original_os.read(self._fileno, size)
             except OSError as e:
                 if get_errno(e) not in SOCKET_BLOCKING:
                     raise IOError(*e.args)


### PR DESCRIPTION
add better compatibility with [FileIO](https://docs.python.org/3.4/library/io.html#io.RawIOBase.read)

required to make pytest work with an active `eventlet.monkey_patch()` on py3