### PR TITLE
wsgi: expose raw HTTP headers in the environment

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -575,9 +575,9 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
         else:
             headers = [h.split(':', 1) for h in headers]
 
-        for k, v in headers:
-            k = k.replace('-', '_').upper()
-            v = v.strip()
+        for raw_k, raw_v in headers:
+            k = raw_k.replace('-', '_').upper()
+            v = raw_v.strip()
             if k in env:
                 continue
             envk = 'HTTP_' + k
@@ -585,6 +585,35 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
                 env[envk] += ',' + v
             else:
                 env[envk] = v
+
+            # In Python 2, these are bytes objects, and they contain the
+            # actual bytes on the wire, so we can just use them as-is.
+            #
+            # In Python 3, these are unicode objects, but they were decoded
+            # from bytes using the iso-8859-1 codec. That codec just maps
+            # byte N to unicode character N for 0 <= N <= 255, so if someone
+            # puts a unicode snowman (\u2603) on the wire as UTF-8
+            # (b"\xe2\x98\x83"), we end up here with a unicode object that's
+            # got 3 codepoints: u"\u00e2\u0098\u0083". This allows us to
+            # recover the original bytes by re-encoding using iso-8859-1.
+            #
+            # Note that the value we end up with has had whitespace stripped
+            # from it. This is because, on Python 2, raw_v still has any
+            # leading and trailing whitespace that was on the wire. However,
+            # on Python 3, that whitespace has already been removed. For
+            # cross-Python-version consistency, we use the stripped value.
+            if six.PY3:
+                raw_bytes_k = raw_k.encode("iso-8859-1")
+                raw_bytes_v = v.encode("iso-8859-1")
+            else:
+                raw_bytes_k = raw_k
+                raw_bytes_v = v
+
+            raw_envk = b'RAWHTTP_' + raw_bytes_k
+            if raw_envk in env:
+                env[raw_envk] += b',' + raw_bytes_v
+            else:
+                env[raw_envk] = raw_bytes_v
 
         if env.get('HTTP_EXPECT') == '100-continue':
             wfile = self.wfile

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -1249,6 +1249,38 @@ class TestHttpd(_TestBase):
         fd.close()
         self.assertEqual(g[0], 1)
 
+    def test_raw_headers(self):
+        got_env = {}
+
+        def capture_env_app(env, start_response):
+            got_env.update(env)
+
+            start_response('200 OK', [('Content-type', 'text/plain')])
+            yield b""
+
+        self.site.application = capture_env_app
+        sock = eventlet.connect(
+            ('localhost', self.port))
+
+        fd = sock.makefile('rwb')
+        fd.write(b'GET / HTTP/1.1\r\n'
+                 b'Host: localhost\r\n'
+                 b'Connection: close\r\n'
+                 b'Unicode-Snowmen: \xe2\x98\x83\r\n'
+                 b'Unicode-Snowmen: \xe2\x9b\x84\r\n'
+                 b'x-amz-meta-sts_image_version: 17\r\n'
+                 b'MIXed-CasE: 1\r\n'
+                 b'\r\n')
+        fd.flush()
+        fd.read()
+
+        self.assertEqual(got_env[b'RAWHTTP_Unicode-Snowmen'],
+                         b'\xe2\x98\x83,\xe2\x9b\x84')
+        self.assertEqual(got_env[b'RAWHTTP_x-amz-meta-sts_image_version'],
+                         b'17')
+        self.assertEqual(got_env[b'RAWHTTP_MIXed-CasE'],
+                         b'1')
+
     def test_zero_length_chunked_response(self):
         def zero_chunked_app(env, start_response):
             start_response('200 OK', [('Content-type', 'text/plain')])


### PR DESCRIPTION
To explain this commit, I'll need to provide three pieces of
background information.

First, PEP 333 gives us rules for how to convert HTTP headers to WSGI
environment keys: uppercase the names, combine repeated headers into
comma-separated strings, and convert dashes to
underscores. Case-mangling and header combining are things that RFC
7230 (HTTP 1.1) defines, but the dash-to-underscore conversion is
something PEP 333 made up to mimic CGI environment variables, and CGI
has dash-to-underscore conversion since a dash is not a valid
character in a shell variable name.

Second, Amazon S3 lets a client authenticate by including an
"Authorization" header in the request; its value is the HMAC of some
normalized form of the request, including certain headers (notably,
those of the form x-amz-meta-*). That normalization includes sorting
and lowercasing, but it does *not* include dash-to-underscore
conversion.

Third, there is a Python project called swift3; it is a WSGI
middleware that attempts to provide an S3-compatible API atop
OpenStack Swift.

An attentive reader may have already noticed the problem: when signing
an S3 request with a header like "x-amz-meta-wing_nut_spin: leftward"
or "x-amz-meta-wing-nut-spin: leftward" the WSGI environment contains
the key HTTP_X_AMZ_WING_NUT_SPIN, but swift3 cannot tell which
underscores were originally dashes and which were originally
underscores, so it has no way to compute the correct HMAC, and thus
cannot authenticate requests.

(Of course, "x-amz-meta-wing_nut_spin" is made up, but
"x-amz-meta-sts_image_version" is a real header emitted by Symantec's
NetBackup product, and I've seen such headers used by bespoke
proprietary apps as well.)

This commit introduces a new set of keys in the WSGI environment:
RAWHTTP_*. If the client sends a header line "Thing-type-One: two",
then the WSGI environment will have env[b"RAWHTTP_Thing-type-One"] =
b"two". Keys are not case-normalized or underscore-normalized, and
both keys and values are of type bytes. Keys and values should match
the bytes put on the wire by the client.

swift3 can use this to get the raw headers sent by the client and
perform its own normalization, thus arriving at the correct HMAC
value.

This is a little more general than swift3 needs, but my hope is that
it is general enough that (a) no more ugly hacks are needed for other
applications that can't abide by WSGI's header mangling, and (b) it
can eventually be adopted by other WSGI servers.

Thanks to Peter Portante for reviewing an early version of this
change.