### PR TITLE
Python 3 compat: Fix TypeError on empty websocket message

### DIFF
--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -560,7 +560,7 @@ class RFC6455WebSocket(WebSocket):
             decoder = self.UTF8Decoder() if opcode == 1 else None
             message = self.Message(opcode, decoder=decoder)
         if not length:
-            message.push('', final=finished)
+            message.push(b'', final=finished)
         else:
             while received < length:
                 d = self.socket.recv(length - received)


### PR DESCRIPTION
This pull request fixes the bug.
  * Empty websocket messages raise TypeError in Python3.