### PR TITLE
WSGI: suppress output of 0-byte chunks

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -485,7 +485,8 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
                     towrite.append(data)
                     towrite_size += len(data)
                     if towrite_size >= minimum_write_chunk_size:
-                        write(b''.join(towrite))
+                        if towrite_size > 0:
+                            write(b''.join(towrite))
                         towrite = []
                         just_written_size = towrite_size
                         towrite_size = 0

--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -479,14 +479,15 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
                 minimum_write_chunk_size = int(self.environ.get(
                     'eventlet.minimum_write_chunk_size', self.minimum_chunk_size))
                 for data in result:
+                    if len(data) == 0:
+                        continue
                     if isinstance(data, six.text_type):
                         data = data.encode('ascii')
 
                     towrite.append(data)
                     towrite_size += len(data)
                     if towrite_size >= minimum_write_chunk_size:
-                        if towrite_size > 0:
-                            write(b''.join(towrite))
+                        write(b''.join(towrite))
                         towrite = []
                         just_written_size = towrite_size
                         towrite_size = 0


### PR DESCRIPTION
Under certain conditions, if the WSGI iterable yields an empty string,
it can cause the response to be terminated.

The conditions are as follows:

  * no minimum chunk size (eventlet.wsgi.server() was called with
    minimum_chunk_size=0, or
    env['eventlet.minimum_write_chunk_size'] = 0)

  * chunked transfer-encoding on the response

In this case, if the WSGI iterable yields an empty string, then
eventlet.wsgi obligingly turns that into "0\r\n\r\n" and writes that
to the socket. This, of course, terminates the response as far as the
client is concerned. However, eventlet.wsgi doesn't notice, so it'll
happily keep calling next(app_iter) and sending the chunks.

If Connection: keep-alive is set, the client might then send the next
request, read some chunked response body, fail to parse it, and then
disconnect.

In other cases, either the 0-byte chunk is saved in the chunk buffer
until the minimum chunk size is met, or 0 bytes get written to the
socket. Those are both no-ops.

This commit discards 0-byte chunks from the WSGI iterable.