### PR TITLE
Add on_open option in WebSocketWSGI

### DIFF
--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -74,12 +74,13 @@ class WebSocketWSGI(object):
     the time of closure.
     """
 
-    def __init__(self, handler):
+    def __init__(self, handler, on_open=None):
         self.handler = handler
         self.protocol_version = None
         self.support_legacy_versions = True
         self.supported_protocols = []
         self.origin_checker = None
+        self.on_open = on_open
 
     @classmethod
     def configured(cls,
@@ -154,6 +155,8 @@ class WebSocketWSGI(object):
             key = struct.pack(">II", key1, key2) + key3
             response = md5(key).digest()
 
+        custom_headers = [] if self.on_open is None else self.on_open(environ)
+
         # Start building the response
         scheme = 'ws'
         if environ.get('wsgi.url_scheme') == 'https':
@@ -173,7 +176,9 @@ class WebSocketWSGI(object):
                 b"Upgrade: WebSocket\r\n"
                 b"Connection: Upgrade\r\n"
                 b"WebSocket-Origin: " + six.b(environ.get('HTTP_ORIGIN')) + b"\r\n"
-                b"WebSocket-Location: " + six.b(location) + b"\r\n\r\n"
+                b"WebSocket-Location: " + six.b(location) + b"\r\n" +
+                self._format_headers(custom_headers) +
+                b"\r\n"
             )
         elif self.protocol_version == 76:
             handshake_reply = (
@@ -183,7 +188,8 @@ class WebSocketWSGI(object):
                 b"Sec-WebSocket-Origin: " + six.b(environ.get('HTTP_ORIGIN')) + b"\r\n"
                 b"Sec-WebSocket-Protocol: " +
                 six.b(environ.get('HTTP_SEC_WEBSOCKET_PROTOCOL', 'default')) + b"\r\n"
-                b"Sec-WebSocket-Location: " + six.b(location) + b"\r\n"
+                b"Sec-WebSocket-Location: " + six.b(location) + b"\r\n" +
+                self._format_headers(custom_headers) +
                 b"\r\n" + response
             )
         else:  # pragma NO COVER
@@ -219,6 +225,8 @@ class WebSocketWSGI(object):
         # if extensions:
         #    extensions = [i.strip() for i in extensions.split(',')]
 
+        custom_headers = [] if self.on_open is None else self.on_open(environ)
+
         key = environ['HTTP_SEC_WEBSOCKET_KEY']
         response = base64.b64encode(sha1(six.b(key) + PROTOCOL_GUID).digest())
         handshake_reply = [b"HTTP/1.1 101 Switching Protocols",
@@ -227,7 +235,8 @@ class WebSocketWSGI(object):
                            b"Sec-WebSocket-Accept: " + response]
         if negotiated_protocol:
             handshake_reply.append(b"Sec-WebSocket-Protocol: " + six.b(negotiated_protocol))
-        sock.sendall(b'\r\n'.join(handshake_reply) + b'\r\n\r\n')
+        sock.sendall(b'\r\n'.join(handshake_reply) + b'\r\n' +
+                     self._format_headers(custom_headers) + b'\r\n')
         return RFC6455WebSocket(sock, environ, self.protocol_version,
                                 protocol=negotiated_protocol)
 
@@ -244,6 +253,12 @@ class WebSocketWSGI(object):
             elif char == " ":
                 spaces += 1
         return int(out) // spaces
+
+    def _format_headers(self, headers):
+        if len(headers) == 0:
+            return b''
+        return six.moves.reduce(lambda x, y: x + y,
+                                [six.b(k) + b': ' + six.b(v) + b'\r\n' for (k, v) in headers])
 
 
 class WebSocket(object):


### PR DESCRIPTION
This pull request adds flexibility on accepting websocket connections as follows.

```Python
import base64
import eventlet
from eventlet import wsgi, websocket
import six
import time


def handle(ws):
    while True:
        message = ws.wait()
        if message is None:
            break
        print("received {0}".format(message))
        ws.send(message)


def on_open(environ):
    if "HTTP_COOKIE" in environ:
        cookie = six.moves.http_cookies.SimpleCookie()
        cookie.load(environ["HTTP_COOKIE"])
        if ("SID" in cookie) and cookie["SID"].value == "validSession":
            return []

    print("not authenticated")

    if "QUERY_STRING" not in environ:
        raise websocket.BadRequest(status="403 Forbidden")

    queries = six.moves.urllib.parse.parse_qs(environ["QUERY_STRING"])
    if "authorization_basic" not in queries:
        raise websocket.BadRequest(status="403 Forbidden")

    if queries["authorization_basic"][0] != base64.b64encode("username:password".encode()).decode():
        raise websocket.BadRequest(status="403 Forbidden")

    expires = time.strftime("%a, %d-%b-%Y %T GMT", time.gmtime(time.time() + 3600))
    return [("Set-Cookie", "SID=validSession; Path=/; Expires={0}".format(expires))]


if __name__ == "__main__":
    wsgi.server(eventlet.listen(("", 8080)), websocket.WebSocketWSGI(handle, on_open=on_open))
```
