### PR TITLE
Added default value for max_size in eventlet's wsgi server.

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -786,7 +786,7 @@ def server(sock, site,
     :param log: File-like object that logs should be written to.
                 If not specified, sys.stderr is used.
     :param environ: Additional parameters that go into the environ dictionary of every request.
-    :param max_size: Maximum number of client connections opened at any time by this server.
+    :param max_size: Maximum number of client connections opened at any time by this server. Default is 1024.
     :param max_http_version: Set to "HTTP/1.0" to make the server pretend it only supports HTTP 1.0.
                 This can help with applications or clients that don't behave properly using HTTP 1.1.
     :param protocol: Protocol class.  Deprecated.


### PR DESCRIPTION
Need to add default value for max_size variable in wsgi server.
While debugging some scale issue in our wsgi server, not getting(through description) how much connections server can support simultaneously.
