### PR TITLE
Avoid set_nonblocking() for GreenPipe on Windows

### DIFF
--- a/eventlet/greenio/py2.py
+++ b/eventlet/greenio/py2.py
@@ -1,5 +1,7 @@
 import errno
 import os
+import sys
+mswindows = (sys.platform == "win32")
 
 from eventlet.greenio.base import (
     _operation_on_closed_file,
@@ -39,7 +41,9 @@ class GreenPipe(_fileobject):
             f.close()
 
         super(GreenPipe, self).__init__(_SocketDuckForFd(fileno), mode)
-        set_nonblocking(self)
+        # Avoid setting non blocking on windows.
+        if not mswindows:
+            set_nonblocking(self)
         self.softspace = 0
 
     @property


### PR DESCRIPTION
GreenPipe init fails on Windows platform due to set_nonblocking() call, however avoiding set_nonblocking() call on windows does works and GreenPipe can be created and used.