### PR TITLE
doc: allow sphinx to create pure text file docs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -11,10 +11,11 @@ PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d _build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest
+.PHONY: help clean text html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  text      to make text files"
 	@echo "  html      to make standalone HTML files"
 	@echo "  dirhtml   to make HTML files named index.html in directories"
 	@echo "  pickle    to make pickle files"
@@ -29,6 +30,11 @@ help:
 
 clean:
 	-rm -rf _build/*
+
+text:
+	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) _build/text
+	@echo
+	@echo "Build finished. The text files are in _build/text."
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) _build/html


### PR DESCRIPTION
A lot of people like simple text file based documentation that can be read on the terminal.
Sphinx allows to create those with the 'text' formatter, this patches includes the according
call in the doc/Makefile.