### PR TITLE
wsgi: extract HTTP-header-to-WSGI-key conversion to method

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -586,7 +586,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
             headers = [h.split(':', 1) for h in headers]
 
         for k, v in headers:
-            k = k.replace('-', '_').upper()
+            k = self.header_name_to_wsgi(k)
             v = v.strip()
             if k in env:
                 continue
@@ -609,6 +609,9 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
         env['eventlet.posthooks'] = []
 
         return env
+
+    def header_name_to_wsgi(self, name):
+        return name.replace('-', '_').upper()
 
     def finish(self):
         try:


### PR DESCRIPTION
This commit's goal is to allow for improved swift3 functionality with
minimal intrusion into eventlet.

swift3 is an Amazon S3 compatibility layer for OpenStack
Swift. OpenStack Swift is a WSGI application using eventlet.wsgi and
swift3 is a WSGI middleware.

Amazon S3 lets a client authenticate by including an "Authorization"
header in the request; its value is the HMAC of some normalized form
of the request, including certain headers (notably, those of the form
x-amz-meta-*). That normalization includes sorting and lowercasing,
but it does *not* include dash-to-underscore conversion. WSGI *does*
include dash-to-underscore conversion, so if the client sends an HTTP
header named x-amz-meta-ice_cream_flavor, swift3 just sees
HTTP_X_AMZ_META_ICE_CREAM_FLAVOR, turns it into
"x-amz-meta-ice-cream-flavor" for hashing, computes the wrong hash,
and rejects the perfectly-valid request.

This commit lets Swift override WSGI's header transformation to
something slightly smarter. The plan is for Swift to swap underscores
and dashes, thus preserving compatibility as best it can while still
letting swift3 compute a signature. Of course, eventlet need not be
involved in that mess; providing the hook is enough.