### PR TITLE
Add Python 3.5 to the Tox and Travis test envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,39 @@
 language: python
-python: 2.7
-env:
-  matrix:
-    - TOX_ENV=pep8
-    - TOX_ENV=py26-epolls
-    - TOX_ENV=py26-poll
-    - TOX_ENV=py26-selects
-    - TOX_ENV=py27-dns
-    - TOX_ENV=py27-epolls
-    - TOX_ENV=py27-poll
-    - TOX_ENV=py27-selects
-    - TOX_ENV=py33-epolls
-    - TOX_ENV=py33-poll
-    - TOX_ENV=py33-selects
-    - TOX_ENV=py34-dns
-    - TOX_ENV=py34-epolls
-    - TOX_ENV=py34-poll
-    - TOX_ENV=py34-selects
-    - TOX_ENV=py35-dns
-    - TOX_ENV=py35-epolls
-    - TOX_ENV=py35-poll
-    - TOX_ENV=py35-selects
-    - TOX_ENV=pypy-dns
-    - TOX_ENV=pypy-epolls
-    - TOX_ENV=pypy-poll
-    - TOX_ENV=pypy-selects
+
 matrix:
   fast_finish: true
+  include:
+
+    - { python: '2.7', env: TOX_ENV=pep8 }
+
+    - { python: '2.6', env: TOX_ENV=py26-epolls }
+    - { python: '2.6', env: TOX_ENV=py26-poll }
+    - { python: '2.6', env: TOX_ENV=py26-selects }
+
+    - { python: '2.7', env: TOX_ENV=py27-dns }
+    - { python: '2.7', env: TOX_ENV=py27-epolls }
+    - { python: '2.7', env: TOX_ENV=py27-poll }
+    - { python: '2.7', env: TOX_ENV=py27-selects }
+
+    - { python: '3.3', env: TOX_ENV=py33-epolls }
+    - { python: '3.3', env: TOX_ENV=py33-poll }
+    - { python: '3.3', env: TOX_ENV=py33-selects }
+
+    - { python: '3.4', env: TOX_ENV=py34-dns }
+    - { python: '3.4', env: TOX_ENV=py34-epolls }
+    - { python: '3.4', env: TOX_ENV=py34-poll }
+    - { python: '3.4', env: TOX_ENV=py34-selects }
+
+    - { python: '3.5', env: TOX_ENV=py35-dns }
+    - { python: '3.5', env: TOX_ENV=py35-epolls }
+    - { python: '3.5', env: TOX_ENV=py35-poll }
+    - { python: '3.5', env: TOX_ENV=py35-selects }
+
+    - { python: 'pypy', env: TOX_ENV=pypy-dns }
+    - { python: 'pypy', env: TOX_ENV=pypy-epolls }
+    - { python: 'pypy', env: TOX_ENV=pypy-poll }
+    - { python: 'pypy', env: TOX_ENV=pypy-selects }
+
   allow_failures:
     - env: TOX_ENV=pypy-dns
     - env: TOX_ENV=pypy-epolls

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ env:
     - TOX_ENV=py34-epolls
     - TOX_ENV=py34-poll
     - TOX_ENV=py34-selects
+    - TOX_ENV=py35-dns
+    - TOX_ENV=py35-epolls
+    - TOX_ENV=py35-poll
+    - TOX_ENV=py35-selects
     - TOX_ENV=pypy-dns
     - TOX_ENV=pypy-epolls
     - TOX_ENV=pypy-poll

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ statistics = 1
 [tox]
 minversion=1.8
 envlist =
-    pep8, py{26,27,33,34,py}-{selects,poll,epolls}, py{27,34,py}-dns
+    pep8, py{26,27,33,34,35,py}-{selects,poll,epolls}, py{27,34,35,py}-dns
 
 [testenv:pep8]
 basepython = python2.7
@@ -39,6 +39,7 @@ basepython =
     py27: python2.7
     py33: python3.3
     py34: python3.4
+    py35: python3.5
     pypy: pypy
 deps =
     nose==1.3.1


### PR DESCRIPTION
This should help catch things like da7f9732.
