### PR TITLE
Fix bug in select.select(): wrong number of args

### DIFF
--- a/eventlet/green/select.py
+++ b/eventlet/green/select.py
@@ -79,9 +79,9 @@ def select(read_list, write_list, error_list, timeout=None):
     try:
         for k, v in six.iteritems(ds):
             if v.get('read'):
-                listeners.append(hub.add(hub.READ, k, on_read, on_error, lambda x: None))
+                listeners.append(hub.add(hub.READ, k, on_read, on_error, lambda: None))
             if v.get('write'):
-                listeners.append(hub.add(hub.WRITE, k, on_write, on_error, lambda x: None))
+                listeners.append(hub.add(hub.WRITE, k, on_write, on_error, lambda: None))
         try:
             return hub.switch()
         finally:


### PR DESCRIPTION
The argument to `mark_as_closed` needs to be a function that takes no arguments as can been seen by the `defang()` method of `eventlet.hub.FdListener`. Without this patch eventlet crashes if `eventlet.hubs.notify_opened()` is called while a `select()` is in progress.

This was the stacktrace we were seeing:

```
Traceback (most recent call last):
[...]
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 67, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 53, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 468, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 576, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 376, in send
    timeout=timeout
  File "/usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/connectionpool.py", line 559, in urlopen
    body=body, headers=headers)
  File "/usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/connectionpool.py", line 353, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python2.7/httplib.py", line 1001, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python2.7/httplib.py", line 1035, in _send_request
    self.endheaders(body)
  File "/usr/lib/python2.7/httplib.py", line 997, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 850, in _send_output
    self.send(msg)
  File "/usr/lib/python2.7/httplib.py", line 812, in send
    self.connect()
  File "/usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/connection.py", line 162, in connect
    conn = self._new_conn()
  File "/usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/connection.py", line 137, in _new_conn
    (self.host, self.port), self.timeout, **extra_kw)
  File "/usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/util/connection.py", line 71, in create_connection
    sock = socket.socket(af, socktype, proto)
  File "/usr/local/lib/python2.7/dist-packages/eventlet/greenio/base.py", line 131, in __init__
    notify_opened(fd.fileno())
  File "/usr/local/lib/python2.7/dist-packages/eventlet/hubs/__init__.py", line 189, in notify_opened
    hub.mark_as_reopened(fd)
  File "/usr/local/lib/python2.7/dist-packages/eventlet/hubs/hub.py", line 241, in mark_as_reopened
    self._obsolete(fileno)
  File "/usr/local/lib/python2.7/dist-packages/eventlet/hubs/hub.py", line 206, in _obsolete
    listener.defang()
  File "/usr/local/lib/python2.7/dist-packages/eventlet/hubs/hub.py", line 73, in defang
    self.mark_as_closed()
TypeError: <lambda>() takes exactly 1 argument (0 given)
```
