### PR TITLE
tox: don't cap pyopenssl to 0.13

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
     py{26,27}-{selects,poll,epolls}: MySQL-python==1.2.5
     py{34,py}-dns: dnspython3==1.12.0
     {selects,poll,epolls}: psycopg2cffi-compat==1.1
-    {selects,poll,epolls}: pyopenssl==0.13
+    {selects,poll,epolls}: pyopenssl
     {selects,poll,epolls}: pyzmq==13.1.0
 commands =
     nosetests --verbose {posargs:tests/}


### PR DESCRIPTION
pyopenssl 0.13 cannot be installed on my Fedora 23. It fails with:

    building 'OpenSSL.crypto' extension
    (...)
    OpenSSL/crypto/crl.c:6:23: erreur: static declaration of ‘X509_REVOKED_dup’ follows non-static declaration
     static X509_REVOKED * X509_REVOKED_dup(X509_REVOKED *orig) {
                           ^
    In file included from /usr/include/openssl/ssl.h:156:0,
                     from OpenSSL/crypto/x509.h:17,
                     from OpenSSL/crypto/crypto.h:30,
                     from OpenSSL/crypto/crl.c:3:
    /usr/include/openssl/x509.h:751:15: note: previous declaration of ‘X509_REVOKED_dup’ was here
     X509_REVOKED *X509_REVOKED_dup(X509_REVOKED *rev);
                   ^
    error: command 'gcc' failed with exit status 1

The bug is known: https://github.com/pyca/pyopenssl/issues/276

The workaround is simple: use a more recent version.