### PR TITLE
Patch logging._lock

### DIFF
--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -369,6 +369,7 @@ def _fix_py3_rlock(old):
         new.acquire()
     if old._is_owned():
         new.acquire()
+    gc.collect()
     for ref in gc.get_referrers(old):
         for k, v in vars(ref):
             if v == old:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,7 +14,7 @@ except ImportError:
 import signal
 try:
     import subprocess32 as subprocess  # py2
-except:
+except ImportError:
     import subprocess  # py3
 import sys
 import unittest
@@ -328,7 +328,7 @@ def run_python(path, env=None, args=None):
     except subprocess.TimeoutExpired:
         p.kill()
         output, _ = p.communicate(timeout=30)
-        return "%s\nFAIL - timed out" % output
+        return "{0}\nFAIL - timed out".format(output)
     return output
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,10 @@ try:
 except ImportError:
     resource = None
 import signal
-import subprocess
+try:
+    import subprocess32 as subprocess  # py2
+except:
+    import subprocess  # py3
 import sys
 import unittest
 import warnings
@@ -320,7 +323,12 @@ def run_python(path, env=None, args=None):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )
-    output, _ = p.communicate()
+    try:
+        output, _ = p.communicate(timeout=30)
+    except subprocess.TimeoutExpired:
+        p.kill()
+        output, _ = p.communicate(timeout=30)
+        return "%s\nFAIL - timed out" % output
     return output
 
 

--- a/tests/isolated/patcher_existing_locks_early.py
+++ b/tests/isolated/patcher_existing_locks_early.py
@@ -1,0 +1,30 @@
+import threading
+
+
+__test__ = False
+
+
+def aaa(lock, e1, e2):
+    e1.set()
+    with lock:
+        e2.wait()
+
+
+def bbb(lock, e1, e2):
+    e1.wait()
+    e2.set()
+    with lock:
+        pass
+
+
+if __name__ == '__main__':
+    test_lock = threading.RLock()
+    import eventlet
+    eventlet.monkey_patch()
+
+    e1, e2 = threading.Event(), threading.Event()
+    a = eventlet.spawn(aaa, test_lock, e1, e2)
+    b = eventlet.spawn(bbb, test_lock, e1, e2)
+    a.wait()
+    b.wait()
+    print('pass')

--- a/tests/isolated/patcher_existing_locks_early.py
+++ b/tests/isolated/patcher_existing_locks_early.py
@@ -1,6 +1,3 @@
-import threading
-
-
 __test__ = False
 
 
@@ -18,6 +15,7 @@ def bbb(lock, e1, e2):
 
 
 if __name__ == '__main__':
+    import threading
     test_lock = threading.RLock()
     import eventlet
     eventlet.monkey_patch()

--- a/tests/isolated/patcher_existing_locks_late.py
+++ b/tests/isolated/patcher_existing_locks_late.py
@@ -1,0 +1,30 @@
+import threading
+
+
+__test__ = False
+
+
+def aaa(lock, e1, e2):
+    e1.set()
+    with lock:
+        e2.wait()
+
+
+def bbb(lock, e1, e2):
+    e1.wait()
+    e2.set()
+    with lock:
+        pass
+
+
+if __name__ == '__main__':
+    import eventlet
+    eventlet.monkey_patch()
+    test_lock = threading.RLock()
+
+    e1, e2 = threading.Event(), threading.Event()
+    a = eventlet.spawn(aaa, test_lock, e1, e2)
+    b = eventlet.spawn(bbb, test_lock, e1, e2)
+    a.wait()
+    b.wait()
+    print('pass')

--- a/tests/isolated/patcher_existing_locks_late.py
+++ b/tests/isolated/patcher_existing_locks_late.py
@@ -1,6 +1,3 @@
-import threading
-
-
 __test__ = False
 
 
@@ -18,6 +15,7 @@ def bbb(lock, e1, e2):
 
 
 if __name__ == '__main__':
+    import threading
     import eventlet
     eventlet.monkey_patch()
     test_lock = threading.RLock()

--- a/tests/isolated/patcher_existing_locks_locked.py
+++ b/tests/isolated/patcher_existing_locks_locked.py
@@ -1,0 +1,42 @@
+__test__ = False
+
+
+def take(lock, sync1, sync2):
+    sync2.acquire()
+    sync1.release()
+    with lock:
+        sync2.release()
+
+
+if __name__ == '__main__':
+    import sys
+    import threading
+    lock = threading.RLock()
+    lock.acquire()
+    import eventlet
+    eventlet.monkey_patch()
+
+    lock.release()
+    try:
+        lock.release()
+    except RuntimeError as e:
+        assert e.args == ('cannot release un-acquired lock',)
+    lock.acquire()
+
+    sync1 = threading.Lock()
+    sync2 = threading.Lock()
+    sync1.acquire()
+    eventlet.spawn(take, lock, sync1, sync2)
+    # Ensure sync2 has been taken
+    with sync1:
+        pass
+
+    # an RLock should be reentrant
+    lock.acquire()
+    lock.release()
+    lock.release()
+    # To acquire sync2, 'take' must have acquired lock, which has been locked
+    # until now
+    sync2.acquire()
+
+    print('pass')

--- a/tests/patcher_test.py
+++ b/tests/patcher_test.py
@@ -506,6 +506,10 @@ def test_patcher_existing_locks_late():
     tests.run_isolated('patcher_existing_locks_late.py')
 
 
+def test_patcher_existing_locks_locked():
+    tests.run_isolated('patcher_existing_locks_locked.py')
+
+
 def test_importlib_lock():
     tests.run_isolated('patcher_importlib_lock.py')
 

--- a/tests/patcher_test.py
+++ b/tests/patcher_test.py
@@ -498,12 +498,12 @@ t2.join()
         self.assertEqual(lines[1], "True", lines[1])
 
 
-class ExistingLocks(ProcessBase):
-    def test_early(self):
-        tests.run_isolated('patcher_existing_locks_early.py')
+def test_patcher_existing_locks_early():
+    tests.run_isolated('patcher_existing_locks_early.py')
 
-    def test_late(self):
-        tests.run_isolated('patcher_existing_locks_late.py')
+
+def test_patcher_existing_locks_late():
+    tests.run_isolated('patcher_existing_locks_late.py')
 
 
 def test_importlib_lock():

--- a/tests/patcher_test.py
+++ b/tests/patcher_test.py
@@ -498,6 +498,14 @@ t2.join()
         self.assertEqual(lines[1], "True", lines[1])
 
 
+class ExistingLocks(ProcessBase):
+    def test_early(self):
+        tests.run_isolated('patcher_existing_locks_early.py')
+
+    def test_late(self):
+        tests.run_isolated('patcher_existing_locks_late.py')
+
+
 def test_importlib_lock():
     tests.run_isolated('patcher_importlib_lock.py')
 

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ basepython =
 deps =
     nose==1.3.1
     setuptools==5.4.1
+    py{26,27}: subprocess32==3.2.7
     py27-dns: dnspython==1.12.0
     py{26,27}-{selects,poll,epolls}: MySQL-python==1.2.5
     py{34,py}-dns: dnspython3==1.12.0


### PR DESCRIPTION
In projects which dynamically determine whether to activate eventlet,
it can be hard not to import a low level module like logging before
eventlet. When logging is imported it initialises a threading.RLock
which it uses to protect the logging configuration. If two
greenthreads attempt to claim this lock, the second one will block the
/native/ thread not just itself.

Replace the unsafe RLock with one which relies on a green Semaphore
while monkey-patching.