### PR TITLE
missing patched ssl module in patched urllib2 module

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -130,4 +130,4 @@ Thanks To
 * Josh VanderLinden
 * Levente Polyak
 * Phus Lu
-* Collin Stocks, fixing urllib2.urlopen() so it accepts cafile, capath, or cadefault arguments
+* Collin Stocks, fixing eventlet.green.urllib2.urlopen() so it accepts cafile, capath, or cadefault arguments

--- a/AUTHORS
+++ b/AUTHORS
@@ -130,3 +130,4 @@ Thanks To
 * Josh VanderLinden
 * Levente Polyak
 * Phus Lu
+* Collin Stocks, fixing urllib2.urlopen() so it accepts cafile, capath, or cadefault arguments

--- a/eventlet/green/urllib2.py
+++ b/eventlet/green/urllib2.py
@@ -2,6 +2,7 @@ from eventlet import patcher
 from eventlet.green import ftplib
 from eventlet.green import httplib
 from eventlet.green import socket
+from eventlet.green import ssl
 from eventlet.green import time
 from eventlet.green import urllib
 
@@ -10,6 +11,7 @@ patcher.inject(
     globals(),
     ('httplib', httplib),
     ('socket', socket),
+    ('ssl', ssl),
     ('time', time),
     ('urllib', urllib))
 

--- a/tests/hub_test.py
+++ b/tests/hub_test.py
@@ -246,7 +246,7 @@ class TestHubBlockingDetector(LimitedTestCase):
 
 
 class TestSuspend(LimitedTestCase):
-    TEST_TIMEOUT = 3
+    TEST_TIMEOUT = 4
     longMessage = True
     maxDiff = None
 

--- a/tests/zmq_test.py
+++ b/tests/zmq_test.py
@@ -19,6 +19,8 @@ def zmq_supported(_):
 
 
 class TestUpstreamDownStream(tests.LimitedTestCase):
+    TEST_TIMEOUT = 2
+
     @tests.skip_unless(zmq_supported)
     def setUp(self):
         super(TestUpstreamDownStream, self).setUp()


### PR DESCRIPTION
Fixes https://github.com/eventlet/eventlet/issues/311.

If you pass `cafile` as an argument to `urllib2.urlopen()`, that tells `urlopen()` to use the `ssl` module to create a default context. Therefore, the patched version of `urllib2` needs a patched version of `ssl`.