### PR TITLE
only trampoline when we block

### DIFF
--- a/eventlet/greenio/py3.py
+++ b/eventlet/greenio/py3.py
@@ -85,7 +85,7 @@ class GreenFileIO(_OriginalIOBase):
             except OSError as e:
                 if get_errno(e) not in SOCKET_BLOCKING:
                     raise IOError(*e.args)
-            self._trampoline(self, read=True)
+                self._trampoline(self, read=True)
 
     def readall(self):
         buf = []
@@ -98,7 +98,7 @@ class GreenFileIO(_OriginalIOBase):
             except OSError as e:
                 if get_errno(e) not in SOCKET_BLOCKING:
                     raise IOError(*e.args)
-            self._trampoline(self, read=True)
+                self._trampoline(self, read=True)
 
     def readinto(self, b):
         up_to = len(b)

--- a/tests/isolated/regular_file_readall.py
+++ b/tests/isolated/regular_file_readall.py
@@ -1,0 +1,41 @@
+import eventlet; eventlet.monkey_patch()
+
+from eventlet.support import six
+import io
+import os
+import tempfile
+
+
+if __name__ == "__main__":
+    with tempfile.NamedTemporaryFile() as tmp:
+        with io.open(tmp.name, "wb") as fp:
+            fp.write(b"content")
+
+        # test BufferedReader.read()
+        fd = os.open(tmp.name, os.O_RDONLY)
+        fp = os.fdopen(fd, "rb")
+        with fp:
+            content = fp.read()
+        assert content == b'content'
+
+        # test FileIO.read()
+        fd = os.open(tmp.name, os.O_RDONLY)
+        fp = os.fdopen(fd, "rb", 0)
+        with fp:
+            content = fp.read()
+        assert content == b'content'
+
+        if six.PY3:
+            # test FileIO.readall()
+            fd = os.open(tmp.name, os.O_RDONLY)
+            fp = os.fdopen(fd, "rb", 0)
+            with fp:
+                content = fp.readall()
+            assert content == b'content'
+
+        # test FileIO.readall() (for Python 2 and Python 3)
+        with io.open(tmp.name, "rb", 0) as fp:
+            content = fp.readall()
+        assert content == b'content'
+
+    print("pass")

--- a/tests/isolated/regular_file_readall.py
+++ b/tests/isolated/regular_file_readall.py
@@ -1,4 +1,5 @@
-import eventlet; eventlet.monkey_patch()
+import eventlet
+eventlet.monkey_patch()
 
 from eventlet.support import six
 import io

--- a/tests/isolated/regular_file_readall.py
+++ b/tests/isolated/regular_file_readall.py
@@ -1,13 +1,14 @@
-import eventlet
-eventlet.monkey_patch()
+__test__ = False
 
-from eventlet.support import six
-import io
-import os
-import tempfile
+if __name__ == '__main__':
+    import eventlet
+    eventlet.monkey_patch()
 
+    from eventlet.support import six
+    import io
+    import os
+    import tempfile
 
-if __name__ == "__main__":
     with tempfile.NamedTemporaryFile() as tmp:
         with io.open(tmp.name, "wb") as fp:
             fp.write(b"content")

--- a/tests/patcher_test.py
+++ b/tests/patcher_test.py
@@ -528,3 +528,7 @@ def test_socketserver_selectors():
 
 def test_blocking_select_methods_are_deleted():
     tests.run_isolated('patcher_blocking_select_methods_are_deleted.py')
+
+
+def test_regular_file_readall():
+    tests.run_isolated('regular_file_readall.py')


### PR DESCRIPTION
### update

bugfix: only trampoline after catching a "blocking" ioerror. trampolining might otherwise fail, e.g. if using epoll and the fd happens to be a regular file (would never block)

test thanks to @haypo from #257

### original description, kept for posterity

wasn't able to figure out how to reproduce in a test, but can be trigged with a pytest test:

```
import eventlet
eventlet.monkey_patch()

pytest_plugins = "pytester"


def test_foo(testdir):

    testdir.makepyfile(
        """
        def test_foo():
            print('foo')
        """
    )
    result = testdir.runpytest()
    assert result.ret == 0
```

hangs on py3 without this patch