### PR TITLE
wsgi: only skip Content-Type and Content-Length headers

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -604,7 +604,8 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
         env['headers_raw'] = headers_raw = tuple((k, v.strip()) for k, v in headers)
         for k, v in headers_raw:
             k = k.replace('-', '_').upper()
-            if k in env:
+            if k in ('CONTENT_TYPE', 'CONTENT_LENGTH'):
+                # These do not get the HTTP_ prefix and were handled above
                 continue
             envk = 'HTTP_' + k
             if envk in env:


### PR DESCRIPTION
Previously, some HTTP headers would not be transcribed to the WSGI environment provided to applications. This could be happen if either:

  * the header closely mirrors another CGI variable, such as `Request-Method` or `Path-Info`, or

  * the header closely mirrors a previous header but prefixed with "Http-", such as `Http-Foo` when a `Foo` header has already been received.

Now, only `Content-Type` and `Content-Length` will be skipped, and only because they were previously already added as `CONTENT_TYPE` and `CONTENT_LENGTH` keys.