### PR TITLE
tpool: Isolate internal socket against socket.setdefaulttimeout() in usercode

### DIFF
--- a/eventlet/tpool.py
+++ b/eventlet/tpool.py
@@ -279,6 +279,7 @@ def setup():
     _wsock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, True)
     sock.close()
     _rsock = greenio.GreenSocket(csock)
+    _rsock.settimeout(None)
 
     for i in six.moves.range(_nthreads):
         t = threading.Thread(target=tworker,


### PR DESCRIPTION
Fixes #193 .

Since commit f37a87b1f8e2f09b8a30c2e947486cf0858650cd the internal implementation of tpool uses sockets instead of pipes for communication. If, for whatever reason, the user code calls socket.setdefaulttimeout() with some nonzero value, the internal socket now inherits this timeout. This causes the tpool to receive a timeout exception where none was expected (as previously the pipe was unaffected by socket.settimeout()). This commit sets settimeout(None) to explicitly set the expected behavior.