### PR TITLE
wsgi: 400 on blank Content-Length headers

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -366,7 +366,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
             self.rfile = orig_rfile
 
         content_length = self.headers.get('content-length')
-        if content_length:
+        if content_length is not None:
             try:
                 int(content_length)
             except ValueError:

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -714,6 +714,20 @@ class TestHttpd(_TestBase):
         assert b'400 Bad Request' in result, result
         assert b'500' not in result, result
 
+        sock = eventlet.connect(self.server_addr)
+        sock.sendall(b'GET / HTTP/1.0\r\nHost: localhost\r\nContent-length:\r\n\r\n')
+        result = recvall(sock)
+        assert result.startswith(b'HTTP'), result
+        assert b'400 Bad Request' in result, result
+        assert b'500' not in result, result
+
+        sock = eventlet.connect(self.server_addr)
+        sock.sendall(b'GET / HTTP/1.0\r\nHost: localhost\r\nContent-length: \r\n\r\n')
+        result = recvall(sock)
+        assert result.startswith(b'HTTP'), result
+        assert b'400 Bad Request' in result, result
+        assert b'500' not in result, result
+
     def test_024_expect_100_continue(self):
         def wsgi_app(environ, start_response):
             if int(environ['CONTENT_LENGTH']) > 1024:


### PR DESCRIPTION
Previously, a client sending a blank Content-Length header would trigger a ValueError in Input.\_\_init\_\_, preventing a response from being sent.

Now, blank Content-Length headers will be treated like non-integer values, and a `400 Bad Request` response will be sent.