### PR TITLE
ssl: Disable SSL v2 and v3 protocols

### DIFF
--- a/doc/ssl.rst
+++ b/doc/ssl.rst
@@ -37,6 +37,7 @@ Here's an example of a server::
 
     # insecure context, only for example purposes
     context = SSL.Context(SSL.SSLv23_METHOD)
+    context.set_options(SSL.OP_NO_SSLv2 | SSL.OP_NO_SSLv3)
     context.set_verify(SSL.VERIFY_NONE, lambda *x: True))
 
     # create underlying green socket and wrap it in ssl

--- a/eventlet/convenience.py
+++ b/eventlet/convenience.py
@@ -140,6 +140,8 @@ except ImportError:
                           suppress_ragged_eofs=True, ciphers=None):
             # theoretically the ssl_version could be respected in this line
             context = SSL.Context(SSL.SSLv23_METHOD)
+            # SSL versions 2 and 3 are considered insecure, disabling
+            context.set_options(SSL.OP_NO_SSLv2 | SSL.OP_NO_SSLv3)
             if certfile is not None:
                 context.use_certificate_file(certfile)
             if keyfile is not None:

--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -67,6 +67,10 @@ class GreenSSLSocket(_original_sslsocket):
             sock.fd, keyfile, certfile, server_side, cert_reqs, ssl_version,
             ca_certs, do_handshake_on_connect and six.PY2, *args, **kw)
 
+        # SSL versions 2 and 3 are considered insecure, disabling
+        self._context.options |= OP_NO_SSLv2
+        self._context.options |= OP_NO_SSLv3
+
         # the superclass initializer trashes the methods so we remove
         # the local-object versions of them and let the actual class
         # methods shine through
@@ -382,6 +386,10 @@ if hasattr(__ssl, 'sslwrap_simple'):
                                   cert_reqs=CERT_NONE,
                                   ssl_version=PROTOCOL_SSLv23,
                                   ca_certs=None)
+
+        # SSL versions 2 and 3 are considered insecure, disabling
+        ssl_sock._context.options |= ssl.OP_NO_SSLv2
+        ssl_sock._context.options |= ssl.OP_NO_SSLv3
         return ssl_sock
 
 


### PR DESCRIPTION
TLS v1 is widely supported and SSL v2 and v3 have security flaws.