### PR TITLE
greendns: Pre-1.10.0 dnspython support

### DIFF
--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -86,7 +86,7 @@ def is_ipv4_addr(host):
         return False
     try:
         dns.ipv4.inet_aton(host)
-    except dns.exception.SyntaxError:
+    except (dns.exception.SyntaxError, socket.error):
         return False
     else:
         return True
@@ -98,7 +98,7 @@ def is_ipv6_addr(host):
         return False
     try:
         dns.ipv6.inet_aton(host)
-    except dns.exception.SyntaxError:
+    except (dns.exception.SyntaxError, socket.error):
         return False
     else:
         return True
@@ -293,7 +293,10 @@ class ResolverProxy(object):
         self._hosts = hosts_resolver
         self._filename = filename
         self._resolver = dns.resolver.Resolver(filename=self._filename)
-        self._resolver.cache = dns.resolver.LRUCache()
+        if hasattr(dns.resolver, 'LRUCache'):
+            self._resolver.cache = dns.resolver.LRUCache()
+        else:
+            self._resolver.cache = dns.resolver.Cache()
 
     def clear(self):
         self._resolver = dns.resolver.Resolver(filename=self._filename)


### PR DESCRIPTION
Following commit 861d684, eventlet cannot be installed alongside dnspython<1.10.0. This breaks on Ubuntu 12.04, for example, which ships 1.9.4 as a system package.

There are two parts to the fix:

Since version 1.10.0, dnspython's inet_aton functions would raise dns.exception.SyntaxError on invalid address strings. Prior to that, however, inet_aton was a thin wrapper around socket.inet_aton and would therefore raise socket.error on invalid addresses. So we'll catch either error when checking ipv4/6 addresses.

Additionally, dnspython 1.10.0 introduced the LRUCache class. We should fall back to the interval-based Cache class if LRUCache is not available. Note that it is already being used in clear().

Prior to commit 861d684, either of these would have been caught as an ImportError in eventlet/green/socket.py and we would have just assumed dnspython wasn't available.