### PR TITLE
Update ssl error messages to match builtin ssl

### DIFF
--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -116,12 +116,12 @@ class GreenSSLSocket(_original_sslsocket):
                         trampoline(self,
                                    read=True,
                                    timeout=self.gettimeout(),
-                                   timeout_exc=timeout_exc('timed out'))
+                                   timeout_exc=timeout_exc('The read operation timed out'))
                     elif get_errno(exc) == SSL_ERROR_WANT_WRITE:
                         trampoline(self,
                                    write=True,
                                    timeout=self.gettimeout(),
-                                   timeout_exc=timeout_exc('timed out'))
+                                   timeout_exc=timeout_exc('The write operation timed out'))
                     else:
                         raise
 

--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -145,7 +145,7 @@ class GreenSSLSocket(_original_sslsocket):
             return self._call_trampolining(
                 super(GreenSSLSocket, self).send, data, flags)
         else:
-            trampoline(self, write=True, timeout_exc=timeout_exc('timed out'))
+            trampoline(self, write=True, timeout_exc=timeout_exc('The write operation timed out'))
             return socket.send(self, data, flags)
 
     def sendto(self, data, addr, flags=0):
@@ -154,7 +154,7 @@ class GreenSSLSocket(_original_sslsocket):
             raise ValueError("sendto not allowed on instances of %s" %
                              self.__class__)
         else:
-            trampoline(self, write=True, timeout_exc=timeout_exc('timed out'))
+            trampoline(self, write=True, timeout_exc=timeout_exc('The write operation timed out'))
             return socket.sendto(self, data, addr, flags)
 
     def sendall(self, data, flags=0):
@@ -171,7 +171,7 @@ class GreenSSLSocket(_original_sslsocket):
                 v = self.send(data_to_send)
                 count += v
                 if v == 0:
-                    trampoline(self, write=True, timeout_exc=timeout_exc('timed out'))
+                    trampoline(self, write=True, timeout_exc=timeout_exc('The write operation timed out'))
                 else:
                     data_to_send = data[count:]
             return amount
@@ -185,7 +185,7 @@ class GreenSSLSocket(_original_sslsocket):
                     erno = get_errno(e)
                     if erno in greenio.SOCKET_BLOCKING:
                         trampoline(self, write=True,
-                                   timeout=self.gettimeout(), timeout_exc=timeout_exc('timed out'))
+                                   timeout=self.gettimeout(), timeout_exc=timeout_exc('The write operation timed out'))
                     elif erno in greenio.SOCKET_CLOSED:
                         return ''
                     raise
@@ -241,7 +241,7 @@ class GreenSSLSocket(_original_sslsocket):
                         try:
                             trampoline(
                                 self, read=True,
-                                timeout=self.gettimeout(), timeout_exc=timeout_exc('timed out'))
+                                timeout=self.gettimeout(), timeout_exc=timeout_exc('The read operation timed out'))
                         except IOClosed:
                             return b''
                     elif erno in greenio.SOCKET_CLOSED:
@@ -251,13 +251,13 @@ class GreenSSLSocket(_original_sslsocket):
     def recvfrom(self, addr, buflen=1024, flags=0):
         if not self.act_non_blocking:
             trampoline(self, read=True, timeout=self.gettimeout(),
-                       timeout_exc=timeout_exc('timed out'))
+                       timeout_exc=timeout_exc('The read operation timed out'))
         return super(GreenSSLSocket, self).recvfrom(addr, buflen, flags)
 
     def recvfrom_into(self, buffer, nbytes=None, flags=0):
         if not self.act_non_blocking:
             trampoline(self, read=True, timeout=self.gettimeout(),
-                       timeout_exc=timeout_exc('timed out'))
+                       timeout_exc=timeout_exc('The read operation timed out'))
         return super(GreenSSLSocket, self).recvfrom_into(buffer, nbytes, flags)
 
     def unwrap(self):


### PR DESCRIPTION
Some libraries, e.g. `urllib3`, [look at the message string of an `SSLError`](https://github.com/shazow/urllib3/blob/master/urllib3/response.py#L307) to determine their behavior (in particular, whether to translate some exceptions into their own exception types). This causes a bad interaction with eventlet where running with eventlet causes an `SSLError` to be thrown where previously there was a `urllib3.ReadTimeoutError` (or a `requests` error), breaking exception handling.

While this behavior is a somewhat unfortunate choice on urllib3's part, it seems nice for eventlet not to break compatibility with the Python ssl module here. So this PR would change the error messages to match those set in [_ssl.c](https://github.com/python/cpython/blob/master/Modules/_ssl.c#L2168). It looks like the error messages are [consistent between 2.6 and master](https://github.com/python/cpython/blob/2.6/Modules/_ssl.c#L1333) so this should work on all versions.

EDIT NOTE: I don't really know what I'm doing with eventlet, so please let me know if there's a better way to accomplish this or if I changed any error messages incorrectly :)
