### PR TITLE
Server socket SO_REUSEPORT option

### DIFF
--- a/eventlet/convenience.py
+++ b/eventlet/convenience.py
@@ -40,6 +40,8 @@ def listen(addr, family=socket.AF_INET, backlog=50):
     sock = socket.socket(family, socket.SOCK_STREAM)
     if sys.platform[:3] != "win":
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # NOTE(zhengwei): linux kernel >= 3.9
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
     sock.bind(addr)
     sock.listen(backlog)
     return sock

--- a/tests/convenience_test.py
+++ b/tests/convenience_test.py
@@ -132,9 +132,7 @@ class TestServe(LimitedTestCase):
         lsock1 = eventlet.listen(('localhost', 0))
         port = lsock1.getsockname()[1]
 
-        def same_socket():
-            return eventlet.listen(('localhost', port))
-
-        self.assertRaises(socket.error, same_socket)
+        lsock2 = eventlet.listen(('localhost', port))
         lsock1.close()
-        assert same_socket()
+        lsock2.close()
+        assert True


### PR DESCRIPTION
From linux kernel >= 3.9, it supports the SO_REUSEPORT option that will
allow multiple server socket to listen the same port