### PR TITLE
_recv_loop behaviour with recv_into on closed sock

### DIFF
--- a/eventlet/greenio/base.py
+++ b/eventlet/greenio/base.py
@@ -318,7 +318,7 @@ class GreenSocket(object):
             timeout=self.gettimeout(),
             timeout_exc=socket.timeout("timed out"))
 
-    def _recv_loop(self, recv_meth, *args):
+    def _recv_loop(self, recv_meth, empty_val, *args):
         fd = self.fd
         if self.act_non_blocking:
             return recv_meth(*args)
@@ -340,7 +340,7 @@ class GreenSocket(object):
                 if get_errno(e) in SOCKET_BLOCKING:
                     pass
                 elif get_errno(e) in SOCKET_CLOSED:
-                    return b''
+                    return empty_val
                 else:
                     raise
 
@@ -351,16 +351,16 @@ class GreenSocket(object):
                 raise EOFError()
 
     def recv(self, bufsize, flags=0):
-        return self._recv_loop(self.fd.recv, bufsize, flags)
+        return self._recv_loop(self.fd.recv, b'', bufsize, flags)
 
     def recvfrom(self, bufsize, flags=0):
-        return self._recv_loop(self.fd.recvfrom, bufsize, flags)
+        return self._recv_loop(self.fd.recvfrom, b'', bufsize, flags)
 
     def recv_into(self, buffer, nbytes=0, flags=0):
-        return self._recv_loop(self.fd.recv_into, buffer, nbytes, flags)
+        return self._recv_loop(self.fd.recv_into, 0, buffer, nbytes, flags)
 
     def recvfrom_into(self, buffer, nbytes=0, flags=0):
-        return self._recv_loop(self.fd.recvfrom_into, buffer, nbytes, flags)
+        return self._recv_loop(self.fd.recvfrom_into, 0, buffer, nbytes, flags)
 
     def _send_loop(self, send_method, data, *args):
         if self.act_non_blocking:


### PR DESCRIPTION
make sure `_recv_loop` returns the correct value when `recv_meth` is of
foo_into type (fills a buffer and returns number of bytes, not the data)