### PR TITLE
Fix enumeration of refs

### DIFF
--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -372,9 +372,14 @@ def _fix_py3_rlock(old):
         new.acquire()
     gc.collect()
     for ref in gc.get_referrers(old):
-        for k, v in vars(ref):
-            if v == old:
-                setattr(ref, k, new)
+        try:
+            ref_vars = vars(ref)
+        except TypeError:
+            pass
+        else:
+            for k, v in ref_vars.items():
+                if v == old:
+                    setattr(ref, k, new)
 
 
 def _green_os_modules():


### PR DESCRIPTION
Introduced in #309, this enumeration should be over the items of the dict in order to work correctly.

Of note: I'm running this via Gunicorn 19.6.0 and PyPy 5.5.0-alpha0 & an exception occurs nearly immediately (it seems that PyPy takes a lock on something before executing any Python).