### PR TITLE
Full IPv6 for machines with no IPv4 127.0.0.1

### DIFF
--- a/eventlet/backdoor.py
+++ b/eventlet/backdoor.py
@@ -10,6 +10,7 @@ import traceback
 import eventlet
 from eventlet import hubs
 from eventlet.support import greenlets, get_errno
+from eventlet.support.afinet import ip_defaults
 
 try:
     sys.ps1
@@ -133,4 +134,4 @@ def backdoor(conn_info, locals=None):
 
 
 if __name__ == '__main__':
-    backdoor_server(eventlet.listen(('127.0.0.1', 9000)), {})
+    backdoor_server(eventlet.listen((ip_defaults['core_lo_addr'], 9000)), {})

--- a/eventlet/convenience.py
+++ b/eventlet/convenience.py
@@ -5,9 +5,10 @@ from eventlet import greenpool
 from eventlet import greenthread
 from eventlet.green import socket
 from eventlet.support import greenlets as greenlet
+from eventlet.support.afinet import ip_defaults
 
 
-def connect(addr, family=socket.AF_INET, bind=None):
+def connect(addr, family=ip_defaults['af_inet'], bind=None):
     """Convenience function for opening client sockets.
 
     :param addr: Address of the server to connect to.  For TCP sockets, this is a (host, port) tuple.
@@ -22,7 +23,7 @@ def connect(addr, family=socket.AF_INET, bind=None):
     return sock
 
 
-def listen(addr, family=socket.AF_INET, backlog=50):
+def listen(addr, family=ip_defaults['af_inet'], backlog=50):
     """Convenience function for opening server sockets.  This
     socket can be used in :func:`~eventlet.serve` or a custom ``accept()`` loop.
 

--- a/eventlet/greenio/base.py
+++ b/eventlet/greenio/base.py
@@ -8,6 +8,7 @@ import warnings
 import eventlet
 from eventlet.hubs import trampoline, notify_opened, IOClosed
 from eventlet.support import get_errno, six
+from eventlet.support.afinet import ip_defaults
 
 __all__ = [
     'GreenSocket', '_GLOBAL_DEFAULT_TIMEOUT', 'set_nonblocking',
@@ -129,7 +130,7 @@ class GreenSocket(object):
     # This placeholder is to prevent __getattr__ from creating an infinite call loop
     fd = None
 
-    def __init__(self, family=socket.AF_INET, *args, **kwargs):
+    def __init__(self, family=ip_defaults['af_inet'], *args, **kwargs):
         should_set_nonblocking = kwargs.pop('set_nonblocking', True)
         if isinstance(family, six.integer_types):
             fd = _original_socket(family, *args, **kwargs)

--- a/eventlet/support/afinet.py
+++ b/eventlet/support/afinet.py
@@ -1,0 +1,46 @@
+"""
+Test availabilty of AF_INET6 on a machine
+
+Uses socket API to determine configuration
+"""
+
+from socket import *
+
+def check_ipv6_lo_addr():
+    try:
+        sock = socket(AF_INET6, SOCK_STREAM)
+        sock.bind(('::1', 0))
+        return True
+    except:
+        return False
+
+def check_ipv6_hosts_file():
+    if not check_ipv6_lo_addr():
+        return False
+    addrinfo = getaddrinfo(gethostname(), 0)
+    if (addrinfo[0][0] == AF_INET6):
+        return True
+    return False
+
+core_use_ipv6_lo_addr = check_ipv6_lo_addr()
+use_ipv6_by_default = check_ipv6_hosts_file()
+
+ip_defaults = {}
+
+if core_use_ipv6_lo_addr:
+    ip_defaults['core_lo_addr'] = '::1'
+    ip_defaults['core_af_inet'] = AF_INET6
+else:
+    ip_defaults['core_lo_addr'] = '127.0.0.1'
+    ip_defaults['core_af_inet'] = AF_INET
+
+if use_ipv6_by_default:
+    ip_defaults['af_inet'] = AF_INET6
+    ip_defaults['null_addr'] = '::'
+    ip_defaults['null_cidr'] = '::/0'
+    ip_defaults['lo_addr'] = '::1'
+else:
+    ip_defaults['af_inet'] = AF_INET
+    ip_defaults['null_addr'] = '0.0.0.0'
+    ip_defaults['null_cidr'] = '0.0.0.0/0'
+    ip_defaults['lo_addr'] = '127.0.0.1'

--- a/eventlet/tpool.py
+++ b/eventlet/tpool.py
@@ -22,6 +22,7 @@ import traceback
 import eventlet
 from eventlet import event, greenio, greenthread, patcher, timeout
 from eventlet.support import six
+from eventlet.support.afinet import ip_defaults
 
 __all__ = ['execute', 'Proxy', 'killall', 'set_num_threads']
 
@@ -269,10 +270,10 @@ def setup():
     _rspq = Queue(maxsize=-1)
 
     # connected socket pair
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(('127.0.0.1', 0))
+    sock = socket.socket(ip_defaults['core_af_inet'], socket.SOCK_STREAM)
+    sock.bind((ip_defaults['core_lo_addr'], 0))
     sock.listen(1)
-    csock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    csock = socket.socket(ip_defaults['core_af_inet'], socket.SOCK_STREAM)
     csock.connect(sock.getsockname())
     csock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, True)
     _wsock, _addr = sock.accept()


### PR DESCRIPTION
Detects if ::1 is present, uses it by preference.  If getaddrinfo()
on hostname returns IPv6 address, turn on full IPv6 defaults.

Submitting for comment about approach.  Test coverage needs writing