### PR TITLE
Make hubs use a monotonic clock by default

### DIFF
--- a/eventlet/hubs/epolls.py
+++ b/eventlet/hubs/epolls.py
@@ -1,7 +1,6 @@
 import errno
 from eventlet.support import get_errno
 from eventlet import patcher
-time = patcher.original('time')
 select = patcher.original("select")
 if hasattr(select, 'epoll'):
     epoll = select.epoll
@@ -25,6 +24,8 @@ else:
                     " NOT http://pypi.python.org/pypi/pyepoll/. "
                     " easy_install pyepoll installs the wrong version.")
 
+import monotonic
+
 from eventlet.hubs.hub import BaseHub
 from eventlet.hubs import poll
 from eventlet.hubs.poll import READ, WRITE
@@ -34,7 +35,7 @@ from eventlet.hubs.poll import READ, WRITE
 
 
 class Hub(poll.Hub):
-    def __init__(self, clock=time.time):
+    def __init__(self, clock=monotonic.monotonic):
         BaseHub.__init__(self, clock)
         self.poll = epoll()
         try:

--- a/eventlet/hubs/hub.py
+++ b/eventlet/hubs/hub.py
@@ -19,10 +19,11 @@ else:
             signal.alarm(math.ceil(seconds))
         arm_alarm = alarm_signal
 
+import monotonic
+
 from eventlet import patcher
 from eventlet.hubs import timer, IOClosed
 from eventlet.support import greenlets as greenlet, clear_sys_exc_info, six
-time = patcher.original('time')
 
 g_prevent_multiple_readers = True
 
@@ -113,7 +114,7 @@ class BaseHub(object):
     READ = READ
     WRITE = WRITE
 
-    def __init__(self, clock=time.time):
+    def __init__(self, clock=monotonic.monotonic):
         self.listeners = {READ: {}, WRITE: {}}
         self.secondaries = {READ: {}, WRITE: {}}
         self.closed = []

--- a/eventlet/hubs/kqueue.py
+++ b/eventlet/hubs/kqueue.py
@@ -6,6 +6,8 @@ select = patcher.original('select')
 time = patcher.original('time')
 sleep = time.sleep
 
+import monotonic
+
 from eventlet.hubs.hub import BaseHub, READ, WRITE, noop
 
 
@@ -20,7 +22,7 @@ FILTERS = {READ: select.KQ_FILTER_READ,
 class Hub(BaseHub):
     MAX_EVENTS = 100
 
-    def __init__(self, clock=time.time):
+    def __init__(self, clock=monotonic.monotonic):
         super(Hub, self).__init__(clock)
         self._events = {}
         self._init_kqueue()

--- a/eventlet/hubs/poll.py
+++ b/eventlet/hubs/poll.py
@@ -1,6 +1,8 @@
 import errno
 import sys
 
+import monotonic
+
 from eventlet import patcher
 select = patcher.original('select')
 time = patcher.original('time')
@@ -15,7 +17,7 @@ WRITE_MASK = select.POLLOUT
 
 
 class Hub(BaseHub):
-    def __init__(self, clock=time.time):
+    def __init__(self, clock=monotonic.monotonic):
         super(Hub, self).__init__(clock)
         self.poll = select.poll()
         # poll.modify is new to 2.6

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
     install_requires=(
         'enum-compat',
         'greenlet >= 0.3',
+        'monotonic',
     ),
     zip_safe=False,
     long_description=open(

--- a/tests/hub_test.py
+++ b/tests/hub_test.py
@@ -2,6 +2,8 @@ from __future__ import with_statement
 import sys
 import time
 
+import monotonic
+
 import tests
 from tests import skip_with_pyevent, skip_if_no_itimer, skip_unless
 from tests.patcher_test import ProcessBase
@@ -81,6 +83,10 @@ class TestTimerCleanup(tests.LimitedTestCase):
             self.assert_less_than_equal(hub.timers_canceled,
                                         hub.get_timers_count())
         eventlet.sleep()
+
+    def test_default_hub_uses_monotonic_clock(self):
+        hub = hubs.get_default_hub().Hub()
+        self.assertIs(hub.clock, monotonic.monotonic)
 
 
 class TestScheduleCall(tests.LimitedTestCase):


### PR DESCRIPTION
Note, that this is essentially a simplified version of https://github.com/eventlet/eventlet/pull/303 . The idea here is to make eventlet do "the right thing" by default in the expense of adding a new dependency on monotonic.