### PR TITLE
be explicit about expecting bytes from sock.recv

### DIFF
--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -597,13 +597,13 @@ def getnameinfo(sockaddr, flags):
 
 
 def _net_read(sock, count, expiration):
-    """coro friendly replacement for dns.query._net_write
+    """coro friendly replacement for dns.query._net_read
     Read the specified number of bytes from sock.  Keep trying until we
     either get the desired amount, or we hit EOF.
     A Timeout exception will be raised if the operation is not completed
     by the expiration time.
     """
-    s = ''
+    s = b''
     while count > 0:
         try:
             n = sock.recv(count)
@@ -611,7 +611,7 @@ def _net_read(sock, count, expiration):
             # Q: Do we also need to catch coro.CoroutineSocketWake and pass?
             if expiration - time.time() <= 0.0:
                 raise dns.exception.Timeout
-        if n == '':
+        if n == b'':
             raise EOFError
         count = count - len(n)
         s = s + n


### PR DESCRIPTION
On Python3, calling`eventlet.support.greendns._net_read` will raise "TypeError: Can't convert 'bytes' object to str implicitly".

This happens when resolution is requested over TCP, or if resolution falls back to TCP when the UDP response is truncated (which is how we found it).

The bug was fixed in dnspython [here](https://github.com/rthalley/dnspython/pull/159).

