### PR TITLE
socket: context manager support

### DIFF
--- a/eventlet/greenio/base.py
+++ b/eventlet/greenio/base.py
@@ -431,6 +431,12 @@ class GreenSocket(object):
     def gettimeout(self):
         return self._timeout
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     if "__pypy__" in sys.builtin_module_names:
         def _reuse(self):
             getattr(self.fd, '_sock', self.fd)._reuse()


### PR DESCRIPTION
Fixes #430 

This PR adds the `__enter__` and `__exit__` context manager methods to the green socket class.