### PR TITLE
patcher: Call get_hub() before beginning monkey-patching

### DIFF
--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -1,6 +1,7 @@
 import imp
 import sys
 
+import eventlet
 from eventlet.support import six
 
 
@@ -222,6 +223,12 @@ def monkey_patch(**on):
 
     It's safe to call monkey_patch multiple times.
     """
+
+    # Make sure the hub is completely imported before any
+    # monkey-patching, or we risk recursion if the process of importing
+    # the hub calls into monkey-patched modules.
+    eventlet.hubs.get_hub()
+
     accepted_args = set(('os', 'select', 'socket',
                          'thread', 'time', 'psycopg', 'MySQLdb',
                          'builtins', 'subprocess'))


### PR DESCRIPTION
In some cases -- notably with Python 2.7.13 and the default hub -- the
process of importing the hub involves calling code in a module we
monkey-patch. This leads to recursive imports: the first eventlet
function will call get_hub(), which will try to import the hub, which
will call a monkey-patched module, which will call get_hub() and try to
import the hub again.

To avoid this, make sure the hub is fully imported before
monkey-patching anything.

Closes #401.