### PR TITLE
Drop OpenSSL.rand support

### DIFF
--- a/eventlet/green/OpenSSL/__init__.py
+++ b/eventlet/green/OpenSSL/__init__.py
@@ -1,4 +1,3 @@
-from . import rand
 from . import crypto
 from . import SSL
 from . import tsafe

--- a/eventlet/green/OpenSSL/rand.py
+++ b/eventlet/green/OpenSSL/rand.py
@@ -1,1 +1,0 @@
-from OpenSSL.rand import *

--- a/tests/openssl_test.py
+++ b/tests/openssl_test.py
@@ -12,6 +12,5 @@ def test_import():
 
     import eventlet.green.OpenSSL.SSL
     import eventlet.green.OpenSSL.crypto
-    import eventlet.green.OpenSSL.rand
     import eventlet.green.OpenSSL.tsafe
     import eventlet.green.OpenSSL.version

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     py{26,27}: subprocess32==3.2.7
     py{26,27}-{selects,poll,epolls}: MySQL-python==1.2.5
     py26-{selects,poll,epolls}: pyopenssl==0.13
-    py{27,33,34}-{selects,poll,epolls}: pyopenssl==16.2.0
+    py{27,33,34}-{selects,poll,epolls}: pyopenssl==17.3.0
     {selects,poll,epolls}: psycopg2cffi-compat==1.1
     {selects,poll,epolls}: pyzmq==13.1.0
 commands =


### PR DESCRIPTION
PyOpenSSL deprecated OpenSSL.rand in 17.2.0 and removed it in 17.3.0.
To comply, update min version in tests to 17.3.0 and removes it.
https://pyopenssl.org/en/stable/changelog.html