### PR TITLE
wsgi: improve error message when returning without start_response

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -537,6 +537,9 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
                     self.close_connection = 1
                     return
 
+                if not headers_set:
+                    raise AssertionError("return before start_response()")
+
                 # Set content-length if possible
                 if not headers_sent and hasattr(result, '__len__') and \
                         'Content-Length' not in [h for h, _v in headers_set[1]]:


### PR DESCRIPTION
Today I discovered that if you return from your WSGI function without calling start_response() first, you get a rather unhelpful traceback:

```
Traceback (most recent call last):
  File "your-python/site-packages/eventlet/wsgi.py", line 515, in handle_one_response
    'Content-Length' not in [h for h, _v in headers_set[1]]:
IndexError: list index out of range
```
That you have to call start_response() before returning is WSGI 101, but I probably should have been asleep a few hours ago, so it took me a while to work backwards from this traceback to the error in my code. This patch should be a relatively simple change that makes it clear what the issue is.