### PR TITLE
[websocket] Ensure close the socket even if client does not polite

### DIFF
--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -469,12 +469,13 @@ class WebSocket(object):
     def close(self):
         """Forcibly close the websocket; generally it is preferable to
         return from the handler method."""
-        self._send_closing_frame()
         try:
+            self._send_closing_frame()
             self.socket.shutdown(True)
-        except OSError:
+        except SocketError:
             pass
-        self.socket.close()
+        finally:
+            self.socket.close()
 
 
 class ConnectionClosedError(Exception):
@@ -812,9 +813,10 @@ class RFC6455WebSocket(WebSocket):
     def close(self, close_data=None):
         """Forcibly close the websocket; generally it is preferable to
         return from the handler method."""
-        self._send_closing_frame(close_data=close_data)
         try:
+            self._send_closing_frame(close_data=close_data)
             self.socket.shutdown(socket.SHUT_WR)
-        except OSError:
+        except SocketError:
             pass
-        self.socket.close()
+        finally:
+            self.socket.close()

--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -375,7 +375,6 @@ class WebSocket(object):
         self.environ = environ
         self.version = version
         self.websocket_closed = False
-        self.client_peer = self.socket.getpeername()
         self._buf = b""
         self._msgs = collections.deque()
         self._sendlock = semaphore.Semaphore()
@@ -476,7 +475,9 @@ class WebSocket(object):
             self.socket.shutdown(True)
         except SocketError as e:
             if e.errno != errno.ENOTCONN:
-                self.log.write('Error on socket shutdown {0}: {1}'.format(self.client_peer, e))
+                self.log.write('Error on socket shutdown {0}:{1}: {2}'.format(
+                    self.environ.get('REMOTE_ADDR'), self.environ.get('REMOTE_PORT'), e
+                ))
         finally:
             self.socket.close()
 
@@ -821,6 +822,8 @@ class RFC6455WebSocket(WebSocket):
             self.socket.shutdown(socket.SHUT_WR)
         except SocketError as e:
             if e.errno != errno.ENOTCONN:
-                self.log.write('Error on socket shutdown {0}: {1}'.format(self.client_peer, e))
+                self.log.write('Error on socket shutdown {0}:{1}: {2}'.format(
+                    self.environ.get('REMOTE_ADDR'), self.environ.get('REMOTE_PORT'), e
+                ))
         finally:
             self.socket.close()

--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -470,7 +470,10 @@ class WebSocket(object):
         """Forcibly close the websocket; generally it is preferable to
         return from the handler method."""
         self._send_closing_frame()
-        self.socket.shutdown(True)
+        try:
+            self.socket.shutdown(True)
+        except OSError:
+            pass
         self.socket.close()
 
 
@@ -810,5 +813,8 @@ class RFC6455WebSocket(WebSocket):
         """Forcibly close the websocket; generally it is preferable to
         return from the handler method."""
         self._send_closing_frame(close_data=close_data)
-        self.socket.shutdown(socket.SHUT_WR)
+        try:
+            self.socket.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
         self.socket.close()


### PR DESCRIPTION
### Server example:

```python
import eventlet
from eventlet import wsgi
from eventlet import websocket


@websocket.WebSocketWSGI
def handle(ws):
    if ws.path == '/echo':
        while True:
            m = ws.wait()
            if m is None:
                break
            ws.send(m)


def dispatch(environ, start_response):
    return handle(environ, start_response)


if __name__ == "__main__":
    listener = eventlet.listen(('127.0.0.1', 9999))
    wsgi.server(listener, dispatch)
```

### Not polite client:

```python
import websocket

url = 'ws://127.0.0.1:9999/echo'

conn = websocket.create_connection(url=url)

conn.send('echo ok')
conn.recv()

conn.send_close()

# force close without shutdown
conn.sock.close()
```

### Problem:

```
Traceback (most recent call last):
  File "/home/_/develop/eventlet/eventlet/websocket.py", line 634, in _iter_frames
    message.opcode, message.getvalue())
  File "/home/_/develop/eventlet/eventlet/websocket.py", line 617, in _handle_control_frame
    self.close(close_data=(status, ''))
  File "/home/_/develop/eventlet/eventlet/websocket.py", line 813, in close
    self.socket.shutdown(socket.SHUT_WR)
OSError: [Errno 107] Transport endpoint is not connected

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/_/develop/eventlet/eventlet/wsgi.py", line 539, in handle_one_response
    result = self.application(self.environ, start_response)
  File "/home/_/develop/ec-wss/e_server.py", line 17, in dispatch
    return handle(environ, start_response)
  File "/home/_/develop/eventlet/eventlet/websocket.py", line 129, in __call__
    self.handler(ws)
  File "/home/_/develop/ec-wss/e_server.py", line 10, in handle
    m = ws.wait()
  File "/home/_/develop/eventlet/eventlet/websocket.py", line 776, in wait
    for i in self.iterator:
  File "/home/_/develop/eventlet/eventlet/websocket.py", line 649, in _iter_frames
    self.close(close_data=(1011, 'Internal Server Error'))
  File "/home/_/develop/eventlet/eventlet/websocket.py", line 813, in close
    self.socket.shutdown(socket.SHUT_WR)
OSError: [Errno 107] Transport endpoint is not connected

127.0.0.1 - - [16/Nov/2017 16:59:02] "GET /echo HTTP/1.1" 500 0 0.001304
```

Issue actual not only for **bad** client. Some network problems or client crashes can cause that problem.

Without fix socket will never close and can cause a resource leak.
