### PR TITLE
wsgi string should be latin-1 encoding (here only PATH_INFO is fixed)

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -631,7 +631,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
 
         pq = self.path.split('?', 1)
         env['RAW_PATH_INFO'] = pq[0]
-        env['PATH_INFO'] = urllib.parse.unquote(pq[0])
+        env['PATH_INFO'] = urllib.parse.unquote_to_bytes(pq[0]).decode('latin-1')
         if len(pq) > 1:
             env['QUERY_STRING'] = pq[1]
 

--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -631,7 +631,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
 
         pq = self.path.split('?', 1)
         env['RAW_PATH_INFO'] = pq[0]
-        env['PATH_INFO'] = urllib.parse.unquote_to_bytes(pq[0]).decode('latin-1')
+        env['PATH_INFO'] = urllib.parse.unquote(pq[0]).encode().decode('latin-1')
         if len(pq) > 1:
             env['QUERY_STRING'] = pq[1]
 


### PR DESCRIPTION
According to: https://www.python.org/dev/peps/pep-0333/#unicode-issues

This will fix a possible encoding issue in wsgi app, when percent encoding appeared in URL

Example:
```
Traceback (most recent call last):
  File "/home/stonemoe/Desktop/Code/test/venv/lib/python3.6/site-packages/eventlet/wsgi.py", line 539, in handle_one_response
    result = self.application(self.environ, start_response)
  File "/home/stonemoe/Desktop/Code/test/venv/lib/python3.6/site-packages/flask/app.py", line 1997, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/stonemoe/Desktop/Code/test/venv/lib/python3.6/site-packages/flask_socketio/__init__.py", line 43, in __call__
    start_response)
  File "/home/stonemoe/Desktop/Code/test/venv/lib/python3.6/site-packages/engineio/middleware.py", line 49, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/stonemoe/Desktop/Code/test/venv/lib/python3.6/site-packages/werkzeug/debug/__init__.py", line 468, in __call__
    request.path == self.console_path:
  File "/home/stonemoe/Desktop/Code/test/venv/lib/python3.6/site-packages/werkzeug/utils.py", line 73, in __get__
    value = self.func(obj)
  File "/home/stonemoe/Desktop/Code/test/venv/lib/python3.6/site-packages/werkzeug/wrappers.py", line 596, in path
    self.charset, self.encoding_errors)
  File "/home/stonemoe/Desktop/Code/test/venv/lib/python3.6/site-packages/werkzeug/_compat.py", line 176, in wsgi_decoding_dance
    return s.encode('latin1').decode(charset, errors)
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 11-12: ordinal not in range(256)

127.0.0.1 - - [06/Mar/2018 13:31:44] "GET /test/%E4%BD%A0%E5%A5%BD HTTP/1.0" 500 1603 0.013243
```