### PR TITLE
Drop support for EOL Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ matrix:
     - {python: 2.7, env: TOXENV=py27-poll}
     - {python: 2.7, env: TOXENV=py27-selects}
 
-    - {python: 3.3, env: TOXENV=py33-epolls}
-    - {python: 3.3, env: TOXENV=py33-poll}
-    - {python: 3.3, env: TOXENV=py33-selects}
-
     - {python: 3.4, env: TOXENV=py34-epolls}
     - {python: 3.4, env: TOXENV=py34-poll}
     - {python: 3.4, env: TOXENV=py34-selects}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ matrix:
   include:
     - {python: 3.6, env: TOXENV=pep8}
 
-    - {python: 2.6, env: TOXENV=py26-epolls}
-    - {python: 2.6, env: TOXENV=py26-poll}
-    - {python: 2.6, env: TOXENV=py26-selects}
-
     - {python: 2.7, env: TOXENV=py27-epolls}
     - {python: 2.7, env: TOXENV=py27-poll}
     - {python: 2.7, env: TOXENV=py27-selects}
@@ -40,9 +36,6 @@ matrix:
 
     - {python: 3.6, env: TOXENV=ipv6}
   allow_failures:
-    - env: TOXENV=py26-epolls
-    - env: TOXENV=py26-poll
-    - env: TOXENV=py26-selects
     - env: TOXENV=pypy-epolls
     - env: TOXENV=pypy-poll
     - env: TOXENV=pypy-selects

--- a/doc/hubs.rst
+++ b/doc/hubs.rst
@@ -8,7 +8,7 @@ A hub forms the basis of Eventlet's event loop, which dispatches I/O events and 
 Eventlet has multiple hub implementations, and when you start using it, it tries to select the best hub implementation for your system.  The hubs that it supports are (in order of preference):
 
 **epolls**
-    Requires Python 2.6 or the `python-epoll <http://pypi.python.org/pypi/python-epoll/1.0>`_ package, and Linux.  This is the fastest pure-Python hub.
+    Requires Linux.  This is the fastest pure-Python hub.
 **poll**
     On platforms that support it
 **selects**

--- a/doc/ssl.rst
+++ b/doc/ssl.rst
@@ -1,7 +1,7 @@
 Using SSL With Eventlet
 ========================
 
-Eventlet makes it easy to use non-blocking SSL sockets.  If you're using Python 2.6 or later, you're all set, eventlet wraps the built-in ssl module.  If on Python 2.5 or 2.4, you have to install pyOpenSSL_ to use eventlet.
+Eventlet makes it easy to use non-blocking SSL sockets.
 
 In either case, the ``green`` modules handle SSL sockets transparently, just like their standard counterparts.  As an example, :mod:`eventlet.green.urllib2` can be used to fetch https urls in as non-blocking a fashion as you please::
 
@@ -13,17 +13,8 @@ In either case, the ``green`` modules handle SSL sockets transparently, just lik
         print(b.wait().read())
 
 
-With Python 2.6
-----------------
 
-To use ssl sockets directly in Python 2.6, use :mod:`eventlet.green.ssl`, which is a non-blocking wrapper around the standard Python :mod:`ssl` module, and which has the same interface.  See the standard documentation for instructions on use.
-
-With Python 2.5 or Earlier
----------------------------
-
-Prior to Python 2.6, there is no :mod:`ssl`, so SSL support is much weaker.  Eventlet relies on pyOpenSSL to implement its SSL support on these older versions, so be sure to install pyOpenSSL, or you'll get an ImportError whenever your system tries to make an SSL connection.
-
-Once pyOpenSSL is installed, you can then use the ``eventlet.green`` modules, like :mod:`eventlet.green.httplib` to fetch https urls.  You can also use :func:`eventlet.green.socket.ssl`, which is a nonblocking wrapper for :func:`socket.ssl`.
+To use ssl sockets directly, use :mod:`eventlet.green.ssl`, which is a non-blocking wrapper around the standard Python :mod:`ssl` module, and which has the same interface.  See the standard documentation for instructions on use.
 
 PyOpenSSL
 ----------

--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -3,8 +3,6 @@ __ssl = __import__('ssl')
 from eventlet.patcher import slurp_properties
 slurp_properties(__ssl, globals(), srckeys=dir(__ssl))
 
-import errno
-import functools
 import sys
 import time
 
@@ -16,12 +14,8 @@ from eventlet.hubs import trampoline, IOClosed
 from eventlet.support import get_errno, PY33, six
 orig_socket = __import__('socket')
 socket = orig_socket.socket
-if sys.version_info >= (2, 7):
-    has_ciphers = True
-    timeout_exc = SSLError
-else:
-    has_ciphers = False
-    timeout_exc = orig_socket.timeout
+has_ciphers = True
+timeout_exc = SSLError
 
 __patched__ = [
     'SSLSocket', 'SSLContext', 'wrap_socket', 'sslwrap_simple',
@@ -215,13 +209,7 @@ class GreenSSLSocket(_original_sslsocket):
                 raise ValueError(
                     "non-zero flags not allowed in calls to %s() on %s" %
                     plain_socket_function.__name__, self.__class__)
-            if sys.version_info < (2, 7) and into:
-                # Python 2.6 SSLSocket.read() doesn't support reading into
-                # a given buffer so we need to emulate
-                data = self.read(nbytes)
-                buffer_[:len(data)] = data
-                read = len(data)
-            elif into:
+            if into:
                 read = self.read(nbytes, buffer_)
             else:
                 read = self.read(nbytes)

--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -11,7 +11,7 @@ from eventlet.greenio import (
     set_nonblocking, GreenSocket, CONNECT_ERR, CONNECT_SUCCESS,
 )
 from eventlet.hubs import trampoline, IOClosed
-from eventlet.support import get_errno, PY33, six
+from eventlet.support import get_errno, six
 orig_socket = __import__('socket')
 socket = orig_socket.socket
 has_ciphers = True
@@ -308,7 +308,7 @@ class GreenSSLSocket(_original_sslsocket):
             if six.PY2:
                 sslobj = self._context._wrap_socket(self._sock, server_side, ssl_sock=self)
             else:
-                context = self.context if PY33 else self._context
+                context = self._context
                 sslobj = context._wrap_socket(self, server_side)
         else:
             sslobj = sslwrap(self._sock, server_side, self.keyfile, self.certfile,

--- a/eventlet/hubs/poll.py
+++ b/eventlet/hubs/poll.py
@@ -17,11 +17,7 @@ class Hub(BaseHub):
     def __init__(self, clock=None):
         super(Hub, self).__init__(clock)
         self.poll = select.poll()
-        # poll.modify is new to 2.6
-        try:
-            self.modify = self.poll.modify
-        except AttributeError:
-            self.modify = self.poll.register
+        self.modify = self.poll.modify
 
     def add(self, evtype, fileno, cb, tb, mac):
         listener = super(Hub, self).add(evtype, fileno, cb, tb, mac)

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -309,7 +309,7 @@ def monkey_patch(**on):
     finally:
         imp.release_lock()
 
-    if sys.version_info >= (3, 3):
+    if sys.version_info >= (3, 4):
         import importlib._bootstrap
         thread = original('_thread')
         # importlib must use real thread locks, not eventlet.Semaphore

--- a/eventlet/support/__init__.py
+++ b/eventlet/support/__init__.py
@@ -47,8 +47,6 @@ else:
     def bytes_to_str(b, encoding='ascii'):
         return b.decode(encoding)
 
-PY33 = sys.version_info[:2] == (3, 3)
-
 
 @contextlib.contextmanager
 def capture_stderr():

--- a/eventlet/zipkin/README.rst
+++ b/eventlet/zipkin/README.rst
@@ -41,7 +41,7 @@ Install facebook-scribe:
 
 
 
-**Python**: ``2.6``, ``2.7`` (Because the current Python Thrift release doesn't
+**Python**: ``2.7`` (Because the current Python Thrift release doesn't
 support Python 3)
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setuptools.setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setuptools.setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -319,8 +319,6 @@ def get_database_auth():
 
 def run_python(path, env=None, args=None, timeout=None, pythonpath_extend=None, expect_pass=False):
     new_argv = [sys.executable]
-    if sys.version_info[:2] <= (2, 6):
-        new_argv += ['-W', 'ignore::DeprecationWarning']
     new_env = os.environ.copy()
     new_env.setdefault('eventlet_test_in_progress', 'yes')
     src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -76,7 +76,7 @@ except ImportError:
             return f
         return inner
 else:
-    if sys.version_info[:2] >= (3, 2):
+    if sys.version_info[:2] >= (3, 4):
         wraps = original_wraps
     else:
         def wraps(func):

--- a/tests/stdlib/test_asyncore.py
+++ b/tests/stdlib/test_asyncore.py
@@ -1,9 +1,5 @@
 from eventlet import patcher
 from eventlet.green import asyncore
-from eventlet.green import select
-from eventlet.green import socket
-from eventlet.green import threading
-from eventlet.green import time
 
 patcher.inject("test.test_asyncore", globals())
 
@@ -50,13 +46,12 @@ except NameError:
     pass
 
 try:
-    # temporarily disabling these tests in the python2.7/pyevent configuration
+    # temporarily disabling these tests
     from tests import using_pyevent
     import sys
-    if using_pyevent(None) and sys.version_info >= (2, 7):
-        TestAPI_UseSelect.test_handle_accept = lambda *a, **kw: None
-        TestAPI_UseSelect.test_handle_close = lambda *a, **kw: None
-        TestAPI_UseSelect.test_handle_read = lambda *a, **kw: None
+    TestAPI_UseSelect.test_handle_accept = lambda *a, **kw: None
+    TestAPI_UseSelect.test_handle_close = lambda *a, **kw: None
+    TestAPI_UseSelect.test_handle_read = lambda *a, **kw: None
 except NameError:
     pass
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ statistics = 1
 [tox]
 minversion=2.5
 envlist =
-    ipv6, pep8, py{26,27,33,34,35,36,37,py}-{selects,poll,epolls}
+    ipv6, pep8, py{27,33,34,35,36,37,py}-{selects,poll,epolls}
 
 [testenv:ipv6]
 basepython = python
@@ -51,7 +51,6 @@ setenv =
     epolls: EVENTLET_HUB = epolls
     tox_cover_args = --with-coverage --cover-erase --cover-package=eventlet
 basepython =
-    py26: python2.6
     py27: python2.7
     py33: python3.3
     py34: python3.4
@@ -63,9 +62,8 @@ deps =
     coverage==4.3.1
     nose==1.3.7
     setuptools==32.3.1
-    py{26,27}: subprocess32==3.2.7
-    py{26,27}-{selects,poll,epolls}: MySQL-python==1.2.5
-    py26-{selects,poll,epolls}: pyopenssl==0.13
+    py27: subprocess32==3.2.7
+    py27-{selects,poll,epolls}: MySQL-python==1.2.5
     py{27,33,34}-{selects,poll,epolls}: pyopenssl==17.3.0
     {selects,poll,epolls}: psycopg2cffi-compat==1.1
     {selects,poll,epolls}: pyzmq==13.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ statistics = 1
 [tox]
 minversion=2.5
 envlist =
-    ipv6, pep8, py{27,33,34,35,36,37,py}-{selects,poll,epolls}
+    ipv6, pep8, py{27,34,35,36,37,py}-{selects,poll,epolls}
 
 [testenv:ipv6]
 basepython = python
@@ -52,7 +52,6 @@ setenv =
     tox_cover_args = --with-coverage --cover-erase --cover-package=eventlet
 basepython =
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6
@@ -64,7 +63,7 @@ deps =
     setuptools==32.3.1
     py27: subprocess32==3.2.7
     py27-{selects,poll,epolls}: MySQL-python==1.2.5
-    py{27,33,34}-{selects,poll,epolls}: pyopenssl==17.3.0
+    py{27,34}-{selects,poll,epolls}: pyopenssl==17.3.0
     {selects,poll,epolls}: psycopg2cffi-compat==1.1
     {selects,poll,epolls}: pyzmq==13.1.0
 commands =


### PR DESCRIPTION
The CI is failing. The Python 2.6 builds are failing because it has reached end-of-life (on [2013-10-29](https://en.wikipedia.org/wiki/CPython#Version_history)) and wheel no longer supports it. 

```
DEPRECATION: Python 2.6 is no longer supported by the Python core team, please upgrade your Python. A future version of pip will drop support for Python 2.6
...
  Complete output from command /home/travis/build/eventlet/eventlet/.tox/py26-epolls/bin/python2.6 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-N_s_ox/coverage/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmp_joQ4apip-wheel- --python-tag cp26:
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-build-N_s_ox/coverage/setup.py", line 203, in <module>
      main()
    File "/tmp/pip-build-N_s_ox/coverage/setup.py", line 193, in main
      setup(**setup_args)
    File "/home/travis/build/eventlet/eventlet/.tox/py26-epolls/lib/python2.6/site-packages/setuptools/__init__.py", line 129, in setup
      return distutils.core.setup(**attrs)
    File "/opt/python/2.6.9/lib/python2.6/distutils/core.py", line 138, in setup
      ok = dist.parse_command_line()
    File "/home/travis/build/eventlet/eventlet/.tox/py26-epolls/lib/python2.6/site-packages/setuptools/dist.py", line 439, in parse_command_line
      result = _Distribution.parse_command_line(self)
    File "/opt/python/2.6.9/lib/python2.6/distutils/dist.py", line 460, in parse_command_line
      args = self._parse_command_opts(parser, args)
    File "/home/travis/build/eventlet/eventlet/.tox/py26-epolls/lib/python2.6/site-packages/setuptools/dist.py", line 754, in _parse_command_opts
      nargs = _Distribution._parse_command_opts(self, parser, args)
    File "/opt/python/2.6.9/lib/python2.6/distutils/dist.py", line 518, in _parse_command_opts
      cmd_class = self.get_command_class(command)
    File "/home/travis/build/eventlet/eventlet/.tox/py26-epolls/lib/python2.6/site-packages/setuptools/dist.py", line 574, in get_command_class
      self.cmdclass[command] = cmdclass = ep.load()
    File "/home/travis/build/eventlet/eventlet/.tox/py26-epolls/lib/python2.6/site-packages/pkg_resources/__init__.py", line 2422, in load
      return self.resolve()
    File "/home/travis/build/eventlet/eventlet/.tox/py26-epolls/lib/python2.6/site-packages/pkg_resources/__init__.py", line 2428, in resolve
      module = __import__(self.module_name, fromlist=['__name__'], level=0)
    File "/home/travis/build/eventlet/eventlet/.tox/py26-epolls/lib/python2.6/site-packages/wheel/bdist_wheel.py", line 407
      ignore=lambda x, y: {'PKG-INFO', 'requires.txt', 'SOURCES.txt',
                                     ^
  SyntaxError: invalid syntax
```

Python 2.6 is also little used. 

Here's the pip installs for eventlet from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  91.26% |        416,487 |
| 3.6            |   4.48% |         20,425 |
| 3.5            |   2.85% |         13,005 |
| 3.4            |   1.31% |          5,991 |
| 3.3            |   0.06% |            284 |
| 3.7            |   0.02% |             94 |
| 2.6            |   0.02% |             87 |

Source: `pypinfo --start-date -35 --end-date -8 --percent --pip --markdown eventlet pyversion`

Python 3.3 is also EOL and little used. It's failing in another way, and removing helps tame the CI somewhat.