### PR TITLE
tpool: support dynamic thread increase

### DIFF
--- a/doc/threading.rst
+++ b/doc/threading.rst
@@ -26,5 +26,12 @@ The simplest thing to do with :mod:`~eventlet.tpool` is to :func:`~eventlet.tpoo
 
 By default there are 20 threads in the pool, but you can configure this by setting the environment variable ``EVENTLET_THREADPOOL_SIZE`` to the desired pool size before importing tpool.
 
+Alternatively you can also set the number of threads in the pool to any value
+after importing tpool using the ``set_num_threads`` method as long as you
+haven't called the ``execute`` method.  If the ``execute`` method has already
+been called, only increases to the thread pool size will take immediate effect,
+lower values will not take effect until we kill all the existing threads with a
+call to ``killall``.
+
 .. automodule:: eventlet.tpool
 	:members:


### PR DESCRIPTION
Tpool's number of threads defaults to 20, or the value defined in
environmental variable "EVENTLET_THREADPOOL_SIZE", and this value can be
changed programmatically using method "set_num_threads", but the call to
"set_num_threads" will only have any effect if the "execute" method has
not been called before (since it automatically calls the "setup"
method).

This is usually not a problem for most projects, but when you are
dealing with a big project that relies on many libraries it may be
harder to control if any of those libraries have already called execute
before you try to set the initial its value.

For example in OpenStack most projects rely on a series of common
libraries that handle Services, Messaging, Configurations, DB access,
etc.  And if we want to allow this value to be set in a configuration
file we may encounter some difficulties, because in some cases by the
time we have read the configuration file we are already running a
service, connected to a DB, connected to RabbitMQ, etc.

This patch proposes a new mechanism where we can dynamically increase
the number of threads in the library calling the "set_num_threads"
method at any point in time, which will not only resolve the situation
mentioned before, but it will also provide a nice mechanism to
dynamically increase the value at runtime if necessary.

Decreasing the number of threads is not supported in order to prevent
gaps in the thread numbering.