### PR TITLE
Ensure eventlet SSL HTTPs contexts allow HTTP verify disabled

### DIFF
--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -425,6 +425,7 @@ if hasattr(__ssl, 'SSLContext'):
 
     if hasattr(__ssl, 'create_default_context'):
         _original_create_default_context = __ssl.create_default_context
+        _original_create_default_https_context = __ssl._create_default_https_context
 
         def green_create_default_context(*a, **kw):
             # We can't just monkey-patch on the green version of `wrap_socket`
@@ -435,5 +436,14 @@ if hasattr(__ssl, 'SSLContext'):
             context.__class__ = GreenSSLContext
             return context
 
+        def green_create_default_https_context(*a, **kw):
+            # We can't just monkey-patch on the green version of `wrap_socket`
+            # on to SSLContext instances, but SSLContext.create_default_context
+            # does a bunch of work. Rather than re-implementing it all, just
+            # switch out the __class__ to get our `wrap_socket` implementation
+            context = _original_create_default_https_context(*a, **kw)
+            context.__class__ = GreenSSLContext
+            return context
+
         create_default_context = green_create_default_context
-        _create_default_https_context = green_create_default_context
+        _create_default_https_context = green_create_default_https_context


### PR DESCRIPTION
Python SSL supports a couple of different ways to disable HTTPS
verification, either via an environment variable or via methods defined
in PEP 493. To ensure these work we must call the original
_create_default_https_context function to ensure we are calling the
right default https context (verified or unverified) function according
set by the https context factory.

Fixes #484