### PR TITLE
wsgi: Use byte strings on py2 and unicode strings on py3

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -62,6 +62,8 @@ def addr_to_host_port(addr):
 def encode_dance(s):
     if not isinstance(s, bytes):
         s = s.encode('utf-8', 'replace')
+    if six.PY2:
+        return s
     return s.decode('latin1')
 
 

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -1423,8 +1423,13 @@ class TestHttpd(_TestBase):
         # in all WSGI environment strings application must observe either bytes in latin-1 (ISO-8859-1)
         # or unicode code points \u0000..\u00ff
         # wsgi_decoding_dance from Werkzeug to emulate concerned application
-        decoded = g[0].encode('latin1').decode('utf-8', 'replace')
-        assert decoded == u'/你好'
+        msg = 'Expected PATH_INFO to be a native string, not {0}'.format(type(g[0]))
+        assert isinstance(g[0], str), msg
+        if six.PY2:
+            assert g[0] == u'/你好'.encode('utf-8')
+        else:
+            decoded = g[0].encode('latin1').decode('utf-8', 'replace')
+            assert decoded == u'/你好'
 
     @tests.skip_if_no_ipv6
     def test_ipv6(self):


### PR DESCRIPTION
Closes #488; for some additional context, see #468 and #467.

PEP-0333 says [1]

> all strings referred to in this specification **must** be of type ``str``

but muddied that message earlier with a bunch of talk about

> all strings passed to or from the server must be standard Python byte
> strings, not Unicode objects

PEP-3333 sought to clarify [2] with

> WSGI therefore defines two kinds of "string":
>
> * "Native" strings (which are always implemented using the type
>   named ``str``) that are used for request/response headers and
>   metadata
>
> * "Bytestrings" (which are implemented using the ``bytes`` type
>   in Python 3, and ``str`` elsewhere), that are used for the bodies
>   of requests and responses (e.g. POST/PUT input data and HTML page
>   outputs).
>
> Do not be confused however: even if Python's ``str`` type is actually
> Unicode "under the hood", the *content* of native strings must
> still be translatable to bytes via the Latin-1 encoding!

And later, in "Unicode Issues" [3], it adds

> For values referred to in this specification as "bytestrings"
> (i.e., values read from ``wsgi.input``, passed to ``write()``
> or yielded by the application), the value **must** be of type
> ``bytes`` under Python 3, and ``str`` in earlier versions of
> Python.

So the upshot seems to be

  - All request and response bodies must be bytes, regardless of Python
    version.
  - All headers and other WSGI environment keys need to be native
    strings; i.e. bytes strings on Python 2 and unicode strings on
    Python 3.

[1] https://www.python.org/dev/peps/pep-0333/#unicode-issues
[2] https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
[3] https://www.python.org/dev/peps/pep-3333/#unicode-issues