### PR TITLE
[WIP] A naive attempt to fix Python 3.7 test failures

### DIFF
--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -366,7 +366,7 @@ SSLSocket = GreenSSLSocket
 
 
 def wrap_socket(sock, *a, **kw):
-    return GreenSSLSocket(sock, *a, **kw)
+    return GreenSSLSocket.wrap_socket(sock, *a, **kw)
 
 
 if hasattr(__ssl, 'sslwrap_simple'):


### PR DESCRIPTION
SSLSocket no longer has a public constructor.
Instances are returned by SSLContext.wrap_socket().

See https://github.com/eventlet/eventlet/issues/502