### PR TITLE
wsgi: Don't strip all Unicode whitespace from headers on py3

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -670,7 +670,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
         else:
             headers = [h.split(':', 1) for h in headers]
 
-        env['headers_raw'] = headers_raw = tuple((k, v.strip()) for k, v in headers)
+        env['headers_raw'] = headers_raw = tuple((k, v.strip(' \t\n\r')) for k, v in headers)
         for k, v in headers_raw:
             k = k.replace('-', '_').upper()
             if k in ('CONTENT_TYPE', 'CONTENT_LENGTH'):

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -1598,6 +1598,34 @@ class TestHttpd(_TestBase):
         assert result.body == (b'HTTP_HOST: localhost\nHTTP_HTTP_X_ANY_K: two\n'
                                b'HTTP_PATH_INFO: foo\nHTTP_X_ANY_K: one\n')
 
+    def test_env_header_stripping(self):
+        def app(environ, start_response):
+            start_response('200 OK', [])
+            # On py3, headers get parsed as Latin-1, so send them back out as Latin-1, too
+            return [line if isinstance(line, bytes) else line.encode('latin1')
+                    for kv in sorted(environ.items())
+                    if kv[0].startswith('HTTP_')
+                    for line in ('{0}: {1}\n'.format(*kv),)]
+
+        self.spawn_server(site=app)
+        sock = eventlet.connect(self.server_addr)
+        sock.sendall(
+            b'GET / HTTP/1.1\r\n'
+            b'Host: localhost\r\n'
+            b'spaced:   o   u   t   \r\n'
+            b'trailing: tab\t\r\n'
+            b'trailing-nbsp: \xc2\xa0\r\n'
+            b'null-set: \xe2\x88\x85\r\n\r\n')
+        result = read_http(sock)
+        sock.close()
+        assert result.status == 'HTTP/1.1 200 OK', 'Received status {0!r}'.format(result.status)
+        assert result.body == (
+            b'HTTP_HOST: localhost\n'
+            b'HTTP_NULL_SET: \xe2\x88\x85\n'
+            b'HTTP_SPACED: o   u   t\n'
+            b'HTTP_TRAILING: tab\n'
+            b'HTTP_TRAILING_NBSP: \xc2\xa0\n')
+
     def test_log_disable(self):
         self.spawn_server(log_output=False)
         sock = eventlet.connect(self.server_addr)


### PR DESCRIPTION
An application that wants to accept UTF-8 header values on Python 2 can do so fairly easily: since str is bytes, it can decode from UTF-8 directly and return appropriate errors if that decoding fails.

On Python 3, it gets a little more interesting. Since str is unicode, the bytes-on-the-wire are decoded as Latin-1 before being put in the WSGI environment, so the application must encode as Latin-1 then decode as UTF-8. For the most part, this Just Works as the transformation should be lossless.

Sometimes, however, headers get truncated on py3. This is the result of a difference in how `.strip()` behaves for bytes vs unicode — in particular, there are some unicode characters that are considered whitespace whose Latin-1 encoded byte string is not:

    >>> [x for i in range(256) for x in (chr(i),)
    ...  if x.isspace() and not x.encode('latin1').isspace()]
    ['\x1c', '\x1d', '\x1e', '\x1f', '\x85', '\xa0']

Looking at RFC 7230, it defines header fields as

>   a case-insensitive field name followed by a colon (":"), optional leading whitespace, the field value, and optional trailing whitespace

where "whitespace" is limited to SP or HTAB. So, let's just strip *those* from header values.

Note that (some versions of?) py2's `mimetools.Message` includes the trailing CRLF, so strip that, too.