### PR TITLE
Add locals() call to example backdoor invocation

### DIFF
--- a/doc/modules/backdoor.rst
+++ b/doc/modules/backdoor.rst
@@ -5,7 +5,7 @@ The backdoor module is convenient for inspecting the state of a long-running pro
 
 In the application, spawn a greenthread running backdoor_server on a listening socket::
 
-    eventlet.spawn(backdoor.backdoor_server, eventlet.listen(('localhost', 3000)))
+    eventlet.spawn(backdoor.backdoor_server, eventlet.listen(('localhost', 3000)), locals())
 
 When this is running, the backdoor is accessible via telnet to the specified port.
 


### PR DESCRIPTION
The backdoor server is all but useless without this argument, and only mentioning it on the last line results in people skimming the docs (like yours truly) to not understand how to use the backdoor properly.

If just dumping everything in locals isn't wise for some reason, I'm open to alternatives.