### PR TITLE
wsgi: make Expect 100-continue field-value case-insensitive.

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -684,7 +684,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
             else:
                 env[envk] = v
 
-        if env.get('HTTP_EXPECT') == '100-continue':
+        if env.get('HTTP_EXPECT', '').lower() == '100-continue':
             wfile = self.wfile
             wfile_line = b'HTTP/1.1 100 Continue\r\n'
         else:

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -748,27 +748,29 @@ class TestHttpd(_TestBase):
         result = read_http(sock)
         self.assertEqual(result.status, 'HTTP/1.1 417 Expectation Failed')
         self.assertEqual(result.body, b'failure')
-        fd.write(
-            b'PUT / HTTP/1.1\r\nHost: localhost\r\nContent-length: 7\r\n'
-            b'Expect: 100-continue\r\n\r\ntesting')
-        fd.flush()
-        header_lines = []
-        while True:
-            line = fd.readline()
-            if line == b'\r\n':
-                break
-            else:
-                header_lines.append(line)
-        assert header_lines[0].startswith(b'HTTP/1.1 100 Continue')
-        header_lines = []
-        while True:
-            line = fd.readline()
-            if line == b'\r\n':
-                break
-            else:
-                header_lines.append(line)
-        assert header_lines[0].startswith(b'HTTP/1.1 200 OK')
-        assert fd.read(7) == b'testing'
+
+        for expect_value in ('100-continue', '100-Continue'):
+            fd.write(
+                'PUT / HTTP/1.1\r\nHost: localhost\r\nContent-length: 7\r\n'
+                'Expect: {}\r\n\r\ntesting'.format(expect_value).encode())
+            fd.flush()
+            header_lines = []
+            while True:
+                line = fd.readline()
+                if line == b'\r\n':
+                    break
+                else:
+                    header_lines.append(line)
+            assert header_lines[0].startswith(b'HTTP/1.1 100 Continue')
+            header_lines = []
+            while True:
+                line = fd.readline()
+                if line == b'\r\n':
+                    break
+                else:
+                    header_lines.append(line)
+            assert header_lines[0].startswith(b'HTTP/1.1 200 OK')
+            assert fd.read(7) == b'testing'
         fd.close()
         sock.close()
 


### PR DESCRIPTION
The wsgi component is not handling correctly the Expect 100-continue field value.

I found this using the `aws-sdk-go`, that sends the value `100-Continue` (!= `100-continue`).

See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20