### PR TITLE
Issue 408 fix, Memory leak was generated from Event

### DIFF
--- a/eventlet/greenthread.py
+++ b/eventlet/greenthread.py
@@ -167,7 +167,7 @@ class GreenThread(greenlet.greenlet):
     """
 
     def __init__(self, parent):
-        greenlet.greenlet.__init__(self, self.main, parent)
+        super(GreenThread, self).__init__(self.main, parent)
         self._exit_event = event.Event()
         self._resolving_links = False
         self._exit_funcs = None
@@ -218,13 +218,11 @@ class GreenThread(greenlet.greenlet):
 
     def main(self, function, args, kwargs):
         try:
-            result = function(*args, **kwargs)
+            self._exit_event.send(function(*args, **kwargs))
         except:
             self._exit_event.send_exception(*sys.exc_info())
-            self._resolve_links()
             raise
-        else:
-            self._exit_event.send(result)
+        finally:
             self._resolve_links()
 
     def _resolve_links(self):

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,7 @@ deps =
     py{27,34}-{selects,poll,epolls}: pyopenssl==17.3.0
     setuptools==38.5.1
     {selects,poll,epolls}: pyzmq==17.0.0
+    objgraph==3.4.0
 commands =
     nosetests --verbose {env:tox_cover_args} {posargs:tests/}
     coverage xml -i


### PR DESCRIPTION

#408, fix for MemLeak on event exceptions  …
changes event.py:
  - self._result and self._exc should not be class's static attributes (the Values were passing between the different Event instances)
  - self._exc  should not store exception trace, instead if exception occurred True (references kept them self, causing GC not to collect, Event has _exc and _exc has trace frames object in touched)
  - self._exc  do not need to store exception trace, the same exception is called with the schedule_call_global for self._waiters timers
  - no need to throw self._exc on wait, it is thrown on the switch

  changes greenthread.py: (adjustments)
   - use of super for init inherited class
   - main method, try send, except send_exception and raise, and finally _resolve_links


#408, Test for fix for MemLeak on event exceptions  …
 - added test_no_mem_leaks to event_test.py
 - added tox.ini dependencies objgraph==3.4.0
