### PR TITLE
Added green nanomsg patcher

### DIFF
--- a/eventlet/green/nanomsg.py
+++ b/eventlet/green/nanomsg.py
@@ -11,45 +11,46 @@ from nanomsg import wrapper
 __nanomsg__.__all__ = ['wrapper', 'NanoMsgError', 'NanoMsgAPIError', 'Device', 'Socket']
 
 for name, value in wrapper.nn_symbols():
-  if name.startswith('NN_'):
-      name = name[3:]
-  __nanomsg__.__all__.append(name)
+    if name.startswith('NN_'):
+        name = name[3:]
+    __nanomsg__.__all__.append(name)
 
 __patched__ = ['Socket']
 slurp_properties(__nanomsg__, globals(), ignore=__patched__)
 
+
 class Socket(__nanomsg__.Socket):
 
-  def recv(self, buf=None, flags=0):
-    """Recieve a message."""
+    def recv(self, buf=None, flags=0):
+        """Recieve a message."""
 
-    # Wait for the receive file descriptor using eventlet
-    while True:
+        # Wait for the receive file descriptor using eventlet
+        while True:
 
-      # Call the eventlent hub trampoline function to wait for a notification on the
-      # receive file descriptor.
-      trampoline(self.recv_fd, read=True)
+            # Call the eventlent hub trampoline function to wait for a notification on the
+            # receive file descriptor.
+            trampoline(self.recv_fd, read=True)
 
-      # Don't allow nn_recv() to block
-      flags = flags | __nanomsg__.DONTWAIT
+            # Don't allow nn_recv() to block
+            flags = flags | __nanomsg__.DONTWAIT
 
-      if buf is None:
-          rtn, out_buf = wrapper.nn_recv(self.fd, flags)
-      else:
-          rtn, out_buf = wrapper.nn_recv(self.fd, buf, flags)
+            if buf is None:
+                rtn, out_buf = wrapper.nn_recv(self.fd, flags)
+            else:
+                rtn, out_buf = wrapper.nn_recv(self.fd, buf, flags)
 
-      # Return if we received a valid message
-      if(rtn > 0):
-        return bytes(memoryview(out_buf))[:rtn]
+            # Return if we received a valid message
+            if(rtn > 0):
+                return bytes(memoryview(out_buf))[:rtn]
 
-  def send(self, msg, flags=0):
-    """Send a message"""
+    def send(self, msg, flags=0):
+        """Send a message"""
 
-    while True:
-      trampoline(self.send_fd, write=True)
-      ret = wrapper.nn_send(self.fd, msg, flags | __nanomsg__.DONTWAIT)
-      if(ret > 0):
-        break
+        while True:
+            trampoline(self.send_fd, write=True)
+            ret = wrapper.nn_send(self.fd, msg, flags | __nanomsg__.DONTWAIT)
+            if(ret > 0):
+                break
 
-  def poll(in_sockets, out_sockets, timeout=-1):
-    raise NotImplementedError("poll is not implemented in the nanomsg eventlet wrapper")
+    def poll(in_sockets, out_sockets, timeout=-1):
+        raise NotImplementedError("poll is not implemented in the nanomsg eventlet wrapper")

--- a/eventlet/green/nanomsg.py
+++ b/eventlet/green/nanomsg.py
@@ -1,0 +1,55 @@
+# coding: utf-8
+"""The :mod:`nanomsg` module wraps the :class:`Socket`
+found in :mod:`nanomsg-python <nanomsg>` to be non blocking.
+"""
+
+__nanomsg__ = __import__('nanomsg')
+from eventlet.patcher import slurp_properties
+from eventlet.hubs import trampoline
+from nanomsg import wrapper
+
+__nanomsg__.__all__ = ['wrapper', 'NanoMsgError', 'NanoMsgAPIError', 'Device', 'Socket']
+
+for name, value in wrapper.nn_symbols():
+  if name.startswith('NN_'):
+      name = name[3:]
+  __nanomsg__.__all__.append(name)
+
+__patched__ = ['Socket']
+slurp_properties(__nanomsg__, globals(), ignore=__patched__)
+
+class Socket(__nanomsg__.Socket):
+
+  def recv(self, buf=None, flags=0):
+    """Recieve a message."""
+
+    # Wait for the receive file descriptor using eventlet
+    while True:
+
+      # Call the eventlent hub trampoline function to wait for a notification on the
+      # receive file descriptor.
+      trampoline(self.recv_fd, read=True)
+
+      # Don't allow nn_recv() to block
+      flags = flags | __nanomsg__.DONTWAIT
+
+      if buf is None:
+          rtn, out_buf = wrapper.nn_recv(self.fd, flags)
+      else:
+          rtn, out_buf = wrapper.nn_recv(self.fd, buf, flags)
+
+      # Return if we received a valid message
+      if(rtn > 0):
+        return bytes(memoryview(out_buf))[:rtn]
+
+  def send(self, msg, flags=0):
+    """Send a message"""
+
+    while True:
+      trampoline(self.send_fd, write=True)
+      ret = wrapper.nn_send(self.fd, msg, flags | __nanomsg__.DONTWAIT)
+      if(ret > 0):
+        break
+
+  def poll(in_sockets, out_sockets, timeout=-1):
+    raise NotImplementedError("poll is not implemented in the nanomsg eventlet wrapper")

--- a/eventlet/green/nanomsg.py
+++ b/eventlet/green/nanomsg.py
@@ -8,7 +8,8 @@ from eventlet.patcher import slurp_properties
 from eventlet.hubs import trampoline
 from errno import EAGAIN
 
-__nanomsg__.__all__ = ['wrapper', 'NanoMsgError', 'NanoMsgAPIError', 'Device', 'Socket']
+if not hasattr(__nanomsg__, "__all__"):
+    __nanomsg__.__all__ = ['wrapper', 'NanoMsgError', 'NanoMsgAPIError', 'Device', 'Socket']
 
 for name, value in __nanomsg__.wrapper.nn_symbols():
     if name.startswith('NN_'):


### PR DESCRIPTION
This adds a green nanomsg monkeypatcher. I've tested this in a Flask application using eventlet, and Flask-SocketIO with a background thread.

Example of a subscriber.

```python
from eventlet.green.nanomsg import *

sock = Socket(SUB)
sock.connect("tcp://localhost:6001")
sock.set_string_option(SUB, SUB_SUBSCRIBE, '')

while True:
  msg = sock.recv()
  print(msg)
```