### PR TITLE
wsgi: Return 400 on negative Content-Length request headers

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -436,8 +436,10 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
         content_length = self.headers.get('content-length')
         if content_length is not None:
             try:
-                int(content_length)
+                if int(content_length) < 0:
+                    raise ValueError
             except ValueError:
+                # Negative, or not an int at all
                 self.wfile.write(
                     b"HTTP/1.0 400 Bad Request\r\n"
                     b"Connection: close\r\nContent-length: 0\r\n\r\n")

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -730,6 +730,13 @@ class TestHttpd(_TestBase):
         assert b'400 Bad Request' in result, result
         assert b'500' not in result, result
 
+        sock = eventlet.connect(self.server_addr)
+        sock.sendall(b'GET / HTTP/1.0\r\nHost: localhost\r\nContent-length: -10\r\n\r\n')
+        result = recvall(sock)
+        assert result.startswith(b'HTTP'), result
+        assert b'400 Bad Request' in result, result
+        assert b'500' not in result, result
+
     def test_024_expect_100_continue(self):
         def wsgi_app(environ, start_response):
             if int(environ['CONTENT_LENGTH']) > 1024:


### PR DESCRIPTION
We already 400 missing and non-integer `Content-Length`s, and `Input` almost certainly wasn't intended to handle negative `length`s.

Be sure to close the connection, too -- we have no reason to think that the client's request framing is still good.