### PR TITLE
Proper way to handle websocket WSGI apps

### DIFF
--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -135,7 +135,8 @@ class WebSocketWSGI(object):
         ws._send_closing_frame(True)
         # use this undocumented feature of eventlet.wsgi to ensure that it
         # doesn't barf on the fact that we didn't call start_response
-        return wsgi.ALREADY_HANDLED
+        wsgi.WSGI_LOCAL.already_handled = True
+        return []
 
     def _handle_legacy_request(self, environ):
         if 'eventlet.input' in environ:

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -552,7 +552,8 @@ class TestWebSocket(tests.wsgi_test._TestBase):
         headers, result = resp.split(b"\r\n\r\n")
         msgs = [result.strip(b"\x00\xff")]
         msgs.extend(sock.recv(20).strip(b"\x00\xff") for _ in range(10))
-        assert msgs == [six.b("msg {}".format(i)) for i in range(10)]
+        expect = [six.b("msg {}".format(i)) for i in range(10)] + [b""]
+        assert msgs == expect
         # In case of server error, server will write HTTP 500 response to the socket
         msg = sock.recv(20)
         assert not msg

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -552,7 +552,7 @@ class TestWebSocket(tests.wsgi_test._TestBase):
         headers, result = resp.split(b"\r\n\r\n")
         msgs = [result.strip(b"\x00\xff")]
         msgs.extend(sock.recv(20).strip(b"\x00\xff") for _ in range(10))
-        assert msgs == [six.b("msg %d" % i) for i in range(10)]
+        assert msgs == [six.b("msg {}".format(i)) for i in range(10)]
         # In case of server error, server will write HTTP 500 response to the socket
         msg = sock.recv(20)
         assert not msg

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -528,6 +528,37 @@ class TestWebSocket(tests.wsgi_test._TestBase):
         with eventlet.Timeout(1):
             pool.waitall()
 
+    def test_wrapped_wsgi(self):
+        site = self.site
+
+        def wrapper(environ, start_response):
+            for chunk in site(environ, start_response):
+                yield chunk
+
+        self.site = wrapper
+        self.spawn_server()
+        connect = [
+            "GET /range HTTP/1.1",
+            "Upgrade: WebSocket",
+            "Connection: Upgrade",
+            "Host: {}:{}".format(*self.server_addr),
+            "Origin: http://{}:{}".format(*self.server_addr),
+            "WebSocket-Protocol: ws",
+        ]
+        sock = eventlet.connect(self.server_addr)
+
+        sock.sendall(six.b("\r\n".join(connect) + "\r\n\r\n"))
+        resp = sock.recv(1024)
+        headers, result = resp.split(b"\r\n\r\n")
+        msgs = [result.strip(b"\x00\xff")]
+        msgs.extend(sock.recv(20).strip(b"\x00\xff") for _ in range(10))
+        assert msgs == [six.b("msg %d" % i) for i in range(10)]
+        # In case of server error, server will write HTTP 500 response to the socket
+        msg = sock.recv(20)
+        assert not msg
+        sock.close()
+        eventlet.sleep(0.01)
+
 
 class TestWebSocketSSL(tests.wsgi_test._TestBase):
     def set_site(self):

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -103,7 +103,8 @@ def chunked_post(env, start_response):
 
 def already_handled(env, start_response):
     start_response('200 OK', [('Content-type', 'text/plain')])
-    return wsgi.ALREADY_HANDLED
+    wsgi.WSGI_LOCAL.already_handled = True
+    return []
 
 
 class Site(object):
@@ -115,8 +116,7 @@ class Site(object):
 
 
 class IterableApp(object):
-
-    def __init__(self, send_start_response=False, return_val=wsgi.ALREADY_HANDLED):
+    def __init__(self, send_start_response=False, return_val=()):
         self.send_start_response = send_start_response
         self.return_val = return_val
         self.env = {}
@@ -125,6 +125,8 @@ class IterableApp(object):
         self.env = env
         if self.send_start_response:
             start_response('200 OK', [('Content-type', 'text/plain')])
+        else:
+            wsgi.WSGI_LOCAL.already_handled = True
         return self.return_val
 
 


### PR DESCRIPTION
As I reported at #543, using return value to handle websocket-specific functionalities does not work well.
In this PR, it uses a coroutine-local flag called `wsgi.WSGI_LOCAL.already_handled`.
Just set flag on in websocket app, and then check that in `wsgi.py`

It fixes #543