### PR TITLE
don't crash on PyPy 7.0.0

### DIFF
--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -369,11 +369,9 @@ def _green_existing_locks():
     tid = eventlet.green.thread.get_ident()
     for obj in gc.get_objects():
         if isinstance(obj, rlock_type):
-            if (not py3_style and
-                    isinstance(obj._RLock__block, lock_type)):
+            if not py3_style and isinstance(obj._RLock__block, lock_type):
                 _fix_py2_rlock(obj, tid)
-            elif (py3_style and
-                    not isinstance(obj, pyrlock_type)):
+            elif py3_style and not isinstance(obj, pyrlock_type):
                 _fix_py3_rlock(obj)
 
 


### PR DESCRIPTION
PyPy 7.0.0 uses 'py3-style' rlocks, i.e. they are implemented natively instead of being in pure-python. Fix commit fixes the code in the sense that at least doesn't crash on PyPy, but it still suffers of issue546, as python3.6 does