### PR TITLE
wsgi: fix Input.readline on Python 3

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -165,7 +165,7 @@ class Input(object):
             self.is_hundred_continue_response_sent = True
         try:
             if length == 0:
-                return ""
+                return b""
 
             if length and length < 0:
                 length = None
@@ -198,7 +198,7 @@ class Input(object):
                         length -= datalen
                         if length == 0:
                             break
-                    if use_readline and data[-1] == "\n":
+                    if use_readline and data[-1:] == b"\n":
                         break
                 else:
                     try:

--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -224,7 +224,17 @@ class Input(object):
             return self._do_read(self.rfile.readline, size)
 
     def readlines(self, hint=None):
-        return self._do_read(self.rfile.readlines, hint)
+        if self.chunked_input:
+            lines = []
+            for line in iter(self.readline, b''):
+                lines.append(line)
+                if hint and hint > 0:
+                    hint -= len(line)
+                    if hint <= 0:
+                        break
+            return lines
+        else:
+            return self._do_read(self.rfile.readlines, hint)
 
     def __iter__(self):
         return iter(self.read, b'')

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -1766,6 +1766,9 @@ class TestChunkedInput(_TestBase):
         elif pi == "/lines":
             for x in input:
                 response.append(x)
+        elif pi == "/readline":
+            response.extend(iter(input.readline, b''))
+            response.append(('\nread %d lines' % len(response)).encode())
         elif pi == "/ping":
             input.read()
             response.append(b"pong")
@@ -1867,6 +1870,16 @@ class TestChunkedInput(_TestBase):
         fd = self.connect()
         fd.sendall(req.encode())
         self.assertEqual(read_http(fd).body, b'this is chunked\nline 2\nline3')
+        fd.close()
+
+    def test_chunked_readline_from_input(self):
+        body = self.body()
+        req = "POST /readline HTTP/1.1\r\nContent-Length: %s\r\n" \
+              "transfer-encoding: Chunked\r\n\r\n%s" % (len(body), body)
+
+        fd = self.connect()
+        fd.sendall(req.encode())
+        self.assertEqual(read_http(fd).body, b'this is chunked\nline 2\nline3\nread 3 lines')
         fd.close()
 
     def test_chunked_readline_wsgi_override_minimum_chunk_size(self):

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -1769,6 +1769,9 @@ class TestChunkedInput(_TestBase):
         elif pi == "/readline":
             response.extend(iter(input.readline, b''))
             response.append(('\nread %d lines' % len(response)).encode())
+        elif pi == "/readlines":
+            response.extend(input.readlines())
+            response.append(('\nread %d lines' % len(response)).encode())
         elif pi == "/ping":
             input.read()
             response.append(b"pong")
@@ -1875,6 +1878,16 @@ class TestChunkedInput(_TestBase):
     def test_chunked_readline_from_input(self):
         body = self.body()
         req = "POST /readline HTTP/1.1\r\nContent-Length: %s\r\n" \
+              "transfer-encoding: Chunked\r\n\r\n%s" % (len(body), body)
+
+        fd = self.connect()
+        fd.sendall(req.encode())
+        self.assertEqual(read_http(fd).body, b'this is chunked\nline 2\nline3\nread 3 lines')
+        fd.close()
+
+    def test_chunked_readlines_from_input(self):
+        body = self.body()
+        req = "POST /readlines HTTP/1.1\r\nContent-Length: %s\r\n" \
               "transfer-encoding: Chunked\r\n\r\n%s" % (len(body), body)
 
         fd = self.connect()


### PR DESCRIPTION
Previously, we would compare the last item of a byte string with a newline in a native string. On Python 3, getting a single item from a byte string give you an integer (which will not be equal to any string), so `readline()` would return the entire request body.

While we're at it, fix the return type when the caller requests that zero bytes be read.