### PR TITLE
wsgi: Stop replacing invalid UTF-8 on py3

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -59,14 +59,6 @@ def addr_to_host_port(addr):
     return (host, port)
 
 
-def encode_dance(s):
-    if not isinstance(s, bytes):
-        s = s.encode('utf-8', 'replace')
-    if six.PY2:
-        return s
-    return s.decode('latin1')
-
-
 # Collections of error codes to compare against.  Not all attributes are set
 # on errno module on all platforms, so some are literals :(
 BAD_SOCK = set((errno.EBADF, 10053))
@@ -646,7 +638,10 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
 
         pq = self.path.split('?', 1)
         env['RAW_PATH_INFO'] = pq[0]
-        env['PATH_INFO'] = encode_dance(urllib.parse.unquote(pq[0]))
+        if six.PY2:
+            env['PATH_INFO'] = urllib.parse.unquote(pq[0])
+        else:
+            env['PATH_INFO'] = urllib.parse.unquote(pq[0], encoding='latin1')
         if len(pq) > 1:
             env['QUERY_STRING'] = pq[1]
 


### PR DESCRIPTION
For more context, see #467 and #497.

On py3, `urllib.parse.unquote()` defaults to decoding via UTF-8 and replacing invalid UTF-8 sequences with `\N{REPLACEMENT CHARACTER}`. This causes a few problems:

- Since WSGI requires that bytes be decoded as Latin-1 on py3, we have to do an extra re-encode/decode cycle in `encode_dance()`.
- Applications written for Latin-1 are broken, as there are valid Latin-1 sequences that are mangled because of the replacement.
- Applications written for UTF-8 cannot differentiate between a replacement character that was intentionally sent by the client versus an invalid byte sequence.

Fortunately, `unquote()` allows us to specify the encoding that should be used. By specifying Latin-1, we can drop `encode_dance()` entirely and preserve as much information from the wire as we can.