### PR TITLE
wsgi: Only send 100 Continue response if no response has been sent yet

### DIFF
--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -988,6 +988,67 @@ class TestHttpd(_TestBase):
         fd.close()
         sock.close()
 
+    def test_024d_expect_100_continue_with_eager_app_chunked(self):
+        def wsgi_app(environ, start_response):
+            # app knows it's going to do some time-intensive thing and doesn't
+            # want clients to time out, so it's protocol says to:
+            # * generally expect a successful status code,
+            # * be prepared to eat some whitespace that will get dribbled out
+            #   periodically, and
+            # * parse the final status from the response body.
+            environ['eventlet.minimum_write_chunk_size'] = 0
+            start_response('202 Accepted', [])
+
+            def resp_gen():
+                yield b' '
+                environ['wsgi.input'].read()
+                yield b' '
+                yield b'\n503 Service Unavailable\n\nOops!\n'
+
+            return resp_gen()
+
+        self.site.application = wsgi_app
+        sock = eventlet.connect(self.server_addr)
+        fd = sock.makefile('rwb')
+        fd.write(b'PUT /a HTTP/1.1\r\n'
+                 b'Host: localhost\r\nConnection: close\r\n'
+                 b'Transfer-Encoding: chunked\r\n'
+                 b'Expect: 100-continue\r\n\r\n')
+        fd.flush()
+
+        # Expect the optimistic response
+        header_lines = []
+        while True:
+            line = fd.readline()
+            if line == b'\r\n':
+                break
+            else:
+                header_lines.append(line.strip())
+        self.assertEqual(header_lines[0], b'HTTP/1.1 202 Accepted')
+
+        def chunkify(data):
+            return '{:x}'.format(len(data)).encode('ascii') + b'\r\n' + data + b'\r\n'
+
+        def expect_chunk(data):
+            expected = chunkify(data)
+            self.assertEqual(expected, fd.read(len(expected)))
+
+        # Can even see that initial whitespace
+        expect_chunk(b' ')
+
+        # Send message
+        fd.write(chunkify(b'some data'))
+        fd.write(chunkify(b''))  # end-of-message
+        fd.flush()
+
+        # Expect final response
+        expect_chunk(b' ')
+        expect_chunk(b'\n503 Service Unavailable\n\nOops!\n')
+        expect_chunk(b'')  # end-of-message
+
+        fd.close()
+        sock.close()
+
     def test_025_accept_errors(self):
         debug.hub_exceptions(True)
         listener = greensocket.socket()


### PR DESCRIPTION
Some applications may need to perform some long-running operation during a client-request cycle. To keep the client from timing out while waiting for the response, the application issues a status _pro tempore_, dribbles out whitespace (or some other filler) periodically, and expects the client to parse the final response to confirm success or failure.

Previously, if the application was *too* eager and sent data before ever reading from the request body, we would write headers to the client, send that initial data, but then **still send the `100 Continue`** when the application finally read the request. Since this would occur on a chunk boundary, the client cannot parse the size of the next chunk, and everything goes off the rails.

Now, only be willing to send the 100 Continue response if we have not sent headers to the client.