### PR TITLE
tests: Improve ECONNREFUSED checks

### DIFF
--- a/tests/test__socket_errors.py
+++ b/tests/test__socket_errors.py
@@ -1,3 +1,4 @@
+import errno
 import unittest
 import socket as _original_sock
 from eventlet.green import socket
@@ -18,7 +19,7 @@ class TestSocketErrors(unittest.TestCase):
             self.fail("Shouldn't have connected")
         except socket.error as ex:
             code, text = ex.args
-            assert code in [111, 61, 10061], (code, text)
+            assert code == errno.ECONNREFUSED, 'Expected ECONNREFUSED, got {0} ({1})'.format(code, text)
             assert 'refused' in text.lower(), (code, text)
 
     def test_timeout_real_socket(self):
@@ -54,9 +55,9 @@ class TestSocketErrors(unittest.TestCase):
 
 
 def test_create_connection_refused():
-    errno = None
     try:
         socket.create_connection(('127.0.0.1', 1))
+        assert False, "Shouldn't have connected"
     except socket.error as ex:
-        errno = ex.errno
-    assert errno in [111, 61, 10061], 'Expected socket.error ECONNREFUSED, got {0}'.format(errno)
+        code, text = ex.args
+        assert code == errno.ECONNREFUSED, 'Expected ECONNREFUSED, got {0} ({1})'.format(code, text)


### PR DESCRIPTION
Only the value for the current platform should be considered
valid here, so this check uses the constant from `errno`
module as expected output, instead of hardcoded ints.

Also, this fixes build on MIPS, where ECONNREFUSED is defined
as 146.

Signed-off-by: Ivan A. Melnikov <iv@altlinux.org>