### PR TITLE
backdoor: handle disconnects better

### DIFF
--- a/tests/backdoor_test.py
+++ b/tests/backdoor_test.py
@@ -57,3 +57,19 @@ class BackdoorTest(tests.LimitedTestCase):
         client = socket.socket(socket.AF_UNIX)
         client.connect(SOCKET_PATH)
         self._run_test_on_client_and_server(client, serv)
+
+    def test_quick_client_disconnect(self):
+        listener = socket.socket()
+        listener.bind(('localhost', 0))
+        listener.listen(50)
+        serv = eventlet.spawn(backdoor.backdoor_server, listener)
+        client = socket.socket()
+        client.connect(('localhost', listener.getsockname()[1]))
+        client.close()
+        # can still reconnect; server is running
+        client = socket.socket()
+        client.connect(('localhost', listener.getsockname()[1]))
+        client.close()
+        serv.kill()
+        # wait for the console to discover that it's dead
+        eventlet.sleep(0.1)


### PR DESCRIPTION
Previously, when a client quickly disconnected (causing a `socket.error` before the `SocketConsole` greenlet had a chance to switch), it would break us out of our accept loop, permanently closing the backdoor.

Now, it will just break us out of the interactive session, leaving the server ready to accept another backdoor client.

Tested by running `python -c "import eventlet; from eventlet import backdoor; eventlet.spawn(backdoor.backdoor_server, eventlet.listen(('127.0.0.1', 3000))); eventlet.sleep(600)"` in one window, and various orderings of

- `echo | telnet localhost 3000`
- `sleep 0.1 | telnet 127.0.0.1 3000`

in another while watching for `Connection refused` errors.

Fixes #570