### PR TITLE
wsgi: Work around CPython bug when parsing non-ASCII headers

### DIFF
--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -1534,6 +1534,59 @@ class TestHttpd(_TestBase):
         assert isinstance(g[1], str), msg
         assert g[1] == '/\xbd\xa5\xe5\xa0\xbd\xe4'
 
+    def test_headers_latin1(self):
+        g = []
+
+        def wsgi_app(environ, start_response):
+            g.append(environ)
+            start_response("200 OK", [])
+            return [environ['wsgi.input'].read()]
+
+        self.site.application = wsgi_app
+        sock = eventlet.connect(self.server_addr)
+        sock.sendall(b'PUT / HTTP/1.1\r\n'
+                     b'Snow-Man: ' + u'\N{SNOWMAN}'.encode('utf8') + b'\r\n'
+                     b'Utf-8-' + u'\U0001F334'.encode('utf-8') + b': palm tree\r\n'
+                     b'Content-Length: 4\r\n'
+                     b'\r\ndata')
+        result = read_http(sock)
+        assert result.status == 'HTTP/1.1 200 OK'
+        assert result.body == b'data'
+
+        assert 'HTTP_SNOW_MAN' in g[0]
+        # WSGI demands native strings, either as bytes or decoded-Latin-1
+        assert isinstance(g[0]['HTTP_SNOW_MAN'], str)
+        assert g[0]['HTTP_SNOW_MAN'] == '\xE2\x98\x83'
+
+        assert 'HTTP_UTF_8_\xF0\x9F\x8C\xB4' in [h for h in g[0] if h.startswith('HTTP_')]
+        assert isinstance(g[0]['HTTP_UTF_8_\xF0\x9F\x8C\xB4'], str)
+        assert g[0]['HTTP_UTF_8_\xF0\x9F\x8C\xB4'] == 'palm tree'
+
+        sock.sendall(b'PUT / HTTP/1.1\r\n'
+                     b'Connection: close\r\n'
+                     b'Snow-Man: ' + u'\N{SNOWMAN}'.encode('utf8') + b'\r\n'
+                     b'Utf-8-' + u'\U0001F334'.encode('utf-8') + b': palm tree\r\n'
+                     b'Content-Type: foo/bar\r\n'
+                     b'Transfer-Encoding: chunked\r\n'
+                     b'\r\n'
+                     b'e\r\n'
+                     b'Hello, world!\n\r\n'
+                     b'0\r\n\r\n')
+        result = read_http(sock)
+        assert result.status == 'HTTP/1.1 200 OK'
+        assert result.body == b'Hello, world!\n'
+
+        assert 'HTTP_SNOW_MAN' in g[1]
+        # WSGI demands native strings, either as bytes or decoded-Latin-1
+        assert isinstance(g[1]['HTTP_SNOW_MAN'], str)
+        assert g[1]['HTTP_SNOW_MAN'] == '\xE2\x98\x83'
+
+        assert 'HTTP_UTF_8_\xF0\x9F\x8C\xB4' in [h for h in g[1] if h.startswith('HTTP_')]
+        assert isinstance(g[1]['HTTP_UTF_8_\xF0\x9F\x8C\xB4'], str)
+        assert g[1]['HTTP_UTF_8_\xF0\x9F\x8C\xB4'] == 'palm tree'
+
+        assert g[1]['CONTENT_TYPE'] == 'foo/bar'
+
     @tests.skip_if_no_ipv6
     def test_ipv6(self):
         try:


### PR DESCRIPTION
Under CPython 3, when an out-of-spec client sends non-ascii header *names*, [`email.feedparser` halts parsing](https://github.com/python/cpython/blob/v3.7.3/Lib/email/feedparser.py#L228-L236) and assumes that the non-ASCII header must be part of a message body. This is despite the fact that [`http.client`'s parse_headers](https://github.com/python/cpython/blob/v3.7.3/Lib/http/client.py#L193-L214) (which is [called by the server protocol's `parse_request`](https://github.com/python/cpython/blob/v3.7.3/Lib/http/server.py#L336-L337)) has already determined the boundary between headers and body and has *only* sent the headers to be parsed. This causes the first such header and *all* subsequent headers to be silently ignored.

See also: https://bugs.python.org/issue37093

Under CPython 2, [`httplib` would happily parse non-ASCII headers](https://github.com/python/cpython/blob/v2.7.16/Lib/httplib.py#L340-L344) since [`rfc822` just looks for a colon in the header line](https://github.com/python/cpython/blob/v2.7.16/Lib/rfc822.py#L202-L212). As a result, py2 applications may have been written that not only allowed but even encouraged the use of, say, UTF-8 in user-defined header names and values.

Support such applications in moving to py3 by checking for a payload on the parsed headers; if found, parse it for more headers. A few things worth pointing out about this:

- The parsing does not handle line folding, but our code didn't handle this well on py2 either. Abort parsing.
- Header lines without a colon will also abort parsing, but this is maybe preferable to py2's behavior where the offending line is interpreted as the separator between headers and body and is silently discarded, and the request is allowed to continue. At least on py3, the body will start after the first blank line rather than part way through the (bad) headers.
- Building a WSGI environment normally involves upper-casing the header names, which should be safe due to their case-insensitivity, but it gets more complicated when considering non-ASCII headers:
  * While WSGI requires that the header names and values be interpreted as Latin-1 on py3, that isn't necessarily the encoding preferred by the application.
  * Even if the application wants Latin-1, upper-casing some Latin-1-encodable code points yields a code point that is not Latin-1-encodable, and so should not be used in a WSGI environment.

  So, preserve the existing py2 behavior on py3: Only upper-case `a`-`z`

Drive-by: Be more explicit about when we're branching because of py2/3 differences so when we eventually drop support for py2, we can remove the old path with confidence.