### PR TITLE
Use _imp instead of deprecated imp

### DIFF
--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -1,4 +1,7 @@
-import imp
+try:
+    import _imp as imp
+except ImportError:
+    import imp
 import sys
 
 import eventlet

--- a/eventlet/tpool.py
+++ b/eventlet/tpool.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 import atexit
-import imp
+try:
+    import _imp as imp
+except ImportError:
+    import imp
 import os
 import sys
 import traceback


### PR DESCRIPTION
Module imp is deprecated in favour of importlib. But importlib doesn't
support acquire_lock/release_lock/lock_held. Use internal _imp module
instead.