### PR TITLE
workaround for pathlib on py 3.7

### DIFF
--- a/eventlet/green/os.py
+++ b/eventlet/green/os.py
@@ -103,6 +103,15 @@ def open(file, flags, mode=0o777, dir_fd=None):
         This behaves identically, but collaborates with
         the hub's notify_opened protocol.
     """
+    # pathlib workaround #534 pathlib._NormalAccessor wraps `open` in
+    # `staticmethod` for py < 3.7 but not 3.7. That means we get here with
+    # `file` being a pathlib._NormalAccessor object, and the other arguments
+    # shifted.  Fortunately pathlib doesn't use the `dir_fd` argument, so we
+    # have space in the parameter list. We use some heuristics to detect this
+    # and adjust the parameters (without importing pathlib)
+    if type(file).__name__ == '_NormalAccessor':
+        file, flags, mode, dir_fd = flags, mode, dir_fd, None
+
     if dir_fd is not None:
         fd = __original_open__(file, flags, mode, dir_fd=dir_fd)
     else:

--- a/tests/os_test.py
+++ b/tests/os_test.py
@@ -1,0 +1,11 @@
+import eventlet
+import six
+
+
+if six.PY3:
+    def test_pathlib_open_issue_534():
+        pathlib = eventlet.import_patched('pathlib')
+        path = pathlib.Path(__file__)
+        with path.open():
+            # should not raise
+            pass


### PR DESCRIPTION
pathlib._NormalAccessor wraps `open` in `staticmethod` for py < 3.7 but
not 3.7. That means we `Path.open` calls `green.os.open` with `file`
being a pathlib._NormalAccessor object, and the other arguments shifted.
Fortunately pathlib doesn't use the `dir_fd` argument, so we have space
in the parameter list. We use some heuristics to detect this and adjust
the parameters (without importing pathlib)

fixes #534