### PR TITLE
wsgi: Fix header capitalization on py3

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -554,8 +554,15 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
             # Per HTTP RFC standard, header name is case-insensitive.
             # Please, fix your client to ignore header case if possible.
             if self.capitalize_response_headers:
+                if six.PY2:
+                    def cap(x):
+                        return x.capitalize()
+                else:
+                    def cap(x):
+                        return x.encode('latin1').capitalize().decode('latin1')
+
                 response_headers = [
-                    ('-'.join([x.capitalize() for x in key.split('-')]), value)
+                    ('-'.join([cap(x) for x in key.split('-')]), value)
                     for key, value in response_headers]
 
             headers_set[:] = [status, response_headers]


### PR DESCRIPTION
`str.capitalize()` and `str.upper()` respect unicode capitalization rules on py3, while py2 just translates `a-z` to `A-Z`.

At best, this may cause confusion and unexpected behaviors, such as when `'\xdf'` (a Latin1-encoded ß) becomes `'SS'`; at worst, this causes `UnicodeEncodeErrors` and the server fails to reply, such as when `'\xff'` (a Latin1-encoded ÿ) becomes `'\u0178'` which does not map back into Latin1.

Now, convert everything to bytes before capitalizing so just `a-z` and `A-Z` are affected on both py2 and py3.