### PR TITLE
Fix wsgi.server shutdown for in-flight requests

### DIFF
--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -77,6 +77,11 @@ class WebSocketWSGI(object):
     the time of closure.
     """
 
+    # This tells the wsgi server code that handling a "request" for this WSGI
+    # app should always be considered "idle" and thus able to be shutdown "mid
+    # request" which for websockets means all the time, I guess.
+    _WSGI_APP_ALWAYS_IDLE = True
+
     def __init__(self, handler):
         self.handler = handler
         self.protocol_version = None

--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -390,6 +390,8 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
             self.handle_one_request()
             if self.conn_state[2] == STATE_CLOSE:
                 self.close_connection = 1
+            else:
+                self.conn_state[2] = STATE_IDLE
             if self.close_connection:
                 break
 
@@ -417,6 +419,9 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
             self.protocol_version = self.server.max_http_version
 
         self.raw_requestline = self._read_request_line()
+        # WebSocketWSGI needs us, here, to consider the connection always idle
+        if not getattr(self.server.app, '_WSGI_APP_ALWAYS_IDLE', False):
+            self.conn_state[2] = STATE_REQUEST
         if not self.raw_requestline:
             self.close_connection = 1
             return

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -101,6 +101,17 @@ def chunked_post(env, start_response):
         return [x for x in iter(lambda: env['wsgi.input'].read(1), b'')]
 
 
+def echo_server(env, start_response):
+    exp_len = int(env['CONTENT_LENGTH'])
+    got_body = env['wsgi.input'].read(exp_len)
+    start_response('200 OK', [
+        ('Content-type', 'application/octet-stream'),
+        ('Content-Length', str(len(got_body))),
+        ('X-Path', env['PATH_INFO']),
+    ])
+    return [got_body]
+
+
 def already_handled(env, start_response):
     start_response('200 OK', [('Content-type', 'text/plain')])
     return wsgi.ALREADY_HANDLED
@@ -1747,19 +1758,118 @@ class TestHttpd(_TestBase):
 
     def test_close_idle_connections(self):
         self.reset_timeout(2)
+        self.site.application = echo_server
         pool = eventlet.GreenPool()
-        self.spawn_server(custom_pool=pool)
+        self.spawn_server(custom_pool=pool, debug=True)
         # https://github.com/eventlet/eventlet/issues/188
+        # We want to close idle connections
         sock = eventlet.connect(self.server_addr)
 
-        sock.sendall(b'GET / HTTP/1.1\r\nHost: localhost\r\n\r\n')
+        body = b'ABC' * 10
+        sock.sendall(b'PUT /foo-bar HTTP/1.1\r\nHost: localhost\r\n'
+                     b'Content-Length: %d\r\n\r\n' % len(body))
+        sock.sendall(body)
         result = read_http(sock)
-        assert result.status == 'HTTP/1.1 200 OK', 'Received status {0!r}'.format(result.status)
+        self.assertEqual('HTTP/1.1 200 OK', result.status,
+                         'Received status {0!r}'.format(result.status))
+        self.assertEqual(body, result.body)
+        self.assertEqual('/foo-bar', result.headers_lower['x-path'])
+
         self.killer.kill(KeyboardInterrupt)
         try:
             with eventlet.Timeout(1):
                 pool.waitall()
         except Exception:
+            assert False, self.logfile.getvalue()
+
+    def test_close_idle_connections_listen_socket_closed(self):
+        self.reset_timeout(4)
+        self.site.application = echo_server
+        pool = eventlet.GreenPool()
+        listen_sock = eventlet.listen(('localhost', 0))
+        self.spawn_server(custom_pool=pool, sock=listen_sock,
+                          debug=True)
+        eventlet.sleep(0)  # need to enter server loop
+
+        # https://github.com/eventlet/eventlet/issues/188
+        # We want to NOT close NON-idle connections
+        sock = eventlet.connect(self.server_addr)
+        eventlet.sleep(0)  # need to enter server loop
+
+        body = b'ABC' * 10
+        sock.sendall(b'PUT /foo-bar HTTP/1.1\r\nHost: localhost\r\n'
+                     b'Content-Length: %d\r\n\r\n' % len(body))
+        eventlet.sleep(0)  # need to enter server loop
+        sock.sendall(body)
+        eventlet.sleep(0)  # need to enter server loop
+        result = read_http(sock)
+        self.assertEqual('HTTP/1.1 200 OK', result.status,
+                         'Received status {0!r}; {1!r}'.format(
+                             result.status, self.logfile.getvalue()))
+        self.assertEqual(body, result.body)
+        self.assertEqual('/foo-bar', result.headers_lower['x-path'])
+        eventlet.sleep(0)  # need to enter server loop
+
+        listen_sock.shutdown(socket.SHUT_RDWR)
+        eventlet.sleep(0)  # need to enter server loop
+        listen_sock.close()
+        eventlet.sleep(0)  # need to enter server loop
+        try:
+            with eventlet.Timeout(1):
+                pool.waitall()
+        except eventlet.Timeout:
+            eventlet.sleep(0)  # need to enter server loop
+            assert False, self.logfile.getvalue()
+
+    def test_do_not_close_non_idle_connections(self):
+        self.reset_timeout(4)
+        self.site.application = echo_server
+        pool = eventlet.GreenPool()
+        listen_sock = eventlet.listen(('localhost', 0))
+        self.spawn_server(custom_pool=pool, sock=listen_sock,
+                          debug=True)
+        eventlet.sleep(0)  # need to enter server loop
+
+        # https://github.com/eventlet/eventlet/issues/188
+        # We want to NOT close NON-idle connections
+        sock = eventlet.connect(self.server_addr)
+        eventlet.sleep(0)  # need to enter server loop
+
+        body = b'ABC' * 10
+        sock.sendall(b'PUT /foo-bar HTTP/1.1\r\nHost: localhost\r\n'
+                     b'Content-Length: %d\r\n\r\n' % len(body))
+        eventlet.sleep(0)  # need to enter server loop
+
+        listen_sock.shutdown(socket.SHUT_RDWR)
+        eventlet.sleep(0)  # need to enter server loop
+        listen_sock.close()
+        eventlet.sleep(0)  # need to enter server loop
+        try:
+            with eventlet.Timeout(1):
+                pool.waitall()
+        except eventlet.Timeout:
+            pass  # we should not exit while that request is still in-flight.
+        else:
+            eventlet.sleep(0)  # need to enter server loop
+            assert False, 'failed to Timeout: %r' % self.logfile.getvalue()
+
+        # Can now finish the request
+        sock.sendall(body)
+        eventlet.sleep(0)  # need to enter server loop
+        result = read_http(sock)
+        self.assertEqual('HTTP/1.1 200 OK', result.status,
+                         'Received status {0!r}; {1!r}'.format(
+                             result.status, self.logfile.getvalue()))
+        self.assertEqual(body, result.body)
+        self.assertEqual('/foo-bar', result.headers_lower['x-path'])
+        eventlet.sleep(0)  # need to enter server loop
+
+        try:
+            eventlet.sleep(0)  # need to enter server loop
+            with eventlet.Timeout(1):
+                eventlet.sleep(0)  # need to enter server loop
+                pool.waitall()
+        except (eventlet.Timeout, Exception):
             assert False, self.logfile.getvalue()
 
 


### PR DESCRIPTION
While doing some work on OpenStack Swift, I noticed that in-flight
requests were getting their sockets closed by eventlet when the listen
socket was closed.  In that case, there is a server process which bound
the listen socket and N fork'ed off worker processes which all run the
wsgi.server loop calling accept() and handling requests.

I noticed that nothing was ever setting connection state to
STATE_REQUEST (i.e. unused constant in previous patch).  Upon closer
inspection, it turns out that the socket cleanup code for STATE_IDLE
sockets got applied to the socket with an in-progress request.  This
caused code using the socket to get an EPIPE and exit the request's
greenthread without completing the request.

With some instrumentation in the code, without this patch's fix, the new
test observed the code doing this:

(7544) wsgi starting up on http://127.0.0.1:36745
(7544) calling accept
(7544) accept got <eventlet.greenio.base.GreenSocket object at 0x7f7650d73290>, ('127.0.0.1', 50194)
(7544) accepted ('127.0.0.1', 50194)
(7544) completed req ('127.0.0.1', 50194)
(7544) calling accept
(7544) got exception 22
(7544) re-raising!
(7544) wsgi exiting, calling pool.waitall()
Traceback (most recent call last):
  File "/tmp/swiftstack-eventlet/eventlet/wsgi.py", line 602, in handle_one_response
    write(b'')
  File "/tmp/swiftstack-eventlet/eventlet/wsgi.py", line 541, in write
    wfile.flush()
  File "/usr/lib64/python2.7/socket.py", line 303, in flush
    self._sock.sendall(view[write_offset:write_offset+buffer_size])
  File "/tmp/swiftstack-eventlet/eventlet/greenio/base.py", line 403, in sendall
    tail = self.send(data, flags)
  File "/tmp/swiftstack-eventlet/eventlet/greenio/base.py", line 397, in send
    return self._send_loop(self.fd.send, data, flags)
  File "/tmp/swiftstack-eventlet/eventlet/greenio/base.py", line 384, in _send_loop
    return send_method(data, *args)
error: [Errno 32] Broken pipe

127.0.0.1 - - [31/Oct/2019 01:08:05] "PUT /foo-bar HTTP/1.1" 200 0 0.000696
(7544) wsgi exited, is_accepting=True

In the new tests, not having the fix manifests as all greenthreads
exiting before the client finishes the in-flight request.

For the WebsocketWSGI app, it has a private class attribute that tells
the wsgi.server() code to consider its "reqeusts" always idle, which I
believe was the primary intent of the original patch.