### PR TITLE
Fix #508: Py37 Deadlock ThreadPoolExecutor

### DIFF
--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -328,6 +328,12 @@ def monkey_patch(**on):
         import threading
         threading.RLock = threading._PyRLock
 
+    # Issue #508: Since Python 3.7 queue.SimpleQueue is implemented in C,
+    # causing a deadlock.  Replace the C implementation with the Python one.
+    if sys.version_info >= (3, 7):
+        import queue
+        queue.SimpleQueue = queue._PySimpleQueue
+
 
 def is_monkey_patched(module):
     """Returns True if the given module is monkeypatched currently, False if

--- a/tests/isolated/patcher_threadpoolexecutor.py
+++ b/tests/isolated/patcher_threadpoolexecutor.py
@@ -1,0 +1,18 @@
+# Issue #508: test ThreadPoolExecutor with monkey-patching
+__test__ = False
+
+if __name__ == '__main__':
+    import eventlet
+    eventlet.monkey_patch()
+
+    import sys
+
+    # Futures is only included in 3.2 or later
+    if sys.version_info >= (3, 2):
+        from concurrent import futures
+
+        with futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(pow, 2, 3)
+            res = future.result()
+        assert res == 8, '2^3 should be 8, not %s' % res
+    print('pass')

--- a/tests/patcher_test.py
+++ b/tests/patcher_test.py
@@ -511,3 +511,7 @@ def test_regular_file_readall():
 
 def test_threading_current():
     tests.run_isolated('patcher_threading_current.py')
+
+
+def test_threadpoolexecutor():
+    tests.run_isolated('patcher_threadpoolexecutor.py')


### PR DESCRIPTION
Python 3.7 and later implement queue.SimpleQueue in C, causing a
deadlock when using ThreadPoolExecutor with eventlet.

To avoid this deadlock we now replace the C implementation with the
Python implementation on monkey_patch for Python versions 3.7 and
higher.

Fix #508 