### PR TITLE
Fix #599: Support bytes in getaddrinfo

### DIFF
--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -265,6 +265,9 @@ class HostsResolver(object):
         if isinstance(qname, six.string_types):
             name = qname
             qname = dns.name.from_text(qname)
+        elif isinstance(qname, six.binary_type):
+            name = qname.decode("ascii")
+            qname = dns.name.from_text(qname)
         else:
             name = str(qname)
         name = name.lower()
@@ -364,7 +367,7 @@ class ResolverProxy(object):
 
         if qname is None:
             qname = '0.0.0.0'
-        if isinstance(qname, six.string_types):
+        if isinstance(qname, six.string_types) or isinstance(qname, six.binary_type):
             qname = dns.name.from_text(qname, None)
 
         def step(fun, *args, **kwargs):
@@ -545,6 +548,8 @@ def getaddrinfo(host, port, family=0, socktype=0, proto=0, flags=0):
     """
     if isinstance(host, six.string_types):
         host = host.encode('idna').decode('ascii')
+    elif isinstance(host, six.binary_type):
+        host = host.decode("ascii")
     if host is not None and not is_ip_addr(host):
         qname, addrs = _getaddrinfo_lookup(host, family, flags)
     else:

--- a/tests/greendns_test.py
+++ b/tests/greendns_test.py
@@ -101,6 +101,10 @@ line2 # inline comment
         hr._v4 = {'v4.example.com': '1.2.3.4'}
         ans = hr.query('v4.example.com')
         assert ans[0].address == '1.2.3.4'
+        ans = hr.query(u'v4.example.com')
+        assert ans[0].address == '1.2.3.4'
+        ans = hr.query(b'v4.example.com')
+        assert ans[0].address == '1.2.3.4'
 
     def test_query_ans_types(self):
         # This assumes test_query_A above succeeds
@@ -321,6 +325,10 @@ class TestProxyResolver(tests.LimitedTestCase):
         rp = greendns.ResolverProxy(hostsres)
         ans = rp.query('host.example.com')
         assert ans[0].address == '1.2.3.4'
+        ans = rp.query(u'host.example.com')
+        assert ans[0].address == '1.2.3.4'
+        ans = rp.query(b'host.example.com')
+        assert ans[0].address == '1.2.3.4'
 
     def test_hosts_noanswer(self):
         hostsres = self._make_mock_hostsresolver()
@@ -337,6 +345,15 @@ class TestProxyResolver(tests.LimitedTestCase):
         rp._resolver = res
         ans = rp.query('host.example.com')
         assert ans[0].address == '5.6.7.8'
+        assert isinstance(res.args[0], dns.name.Name)
+
+        ans = rp.query(u'host.example.com')
+        assert ans[0].address == '5.6.7.8'
+        assert isinstance(res.args[0], dns.name.Name)
+
+        ans = rp.query(b'host.example.com')
+        assert ans[0].address == '5.6.7.8'
+        assert isinstance(res.args[0], dns.name.Name)
 
     def test_noanswer(self):
         res = self._make_mock_resolver()
@@ -657,6 +674,13 @@ class TestGetaddrinfo(tests.LimitedTestCase):
         result = greendns.getaddrinfo('example.com', 0, 0)
         addr = [('1.2.3.4', 0)] * len(result)
         assert addr == [ai[-1] for ai in result]
+
+    def test_getaddrinfo_bytes(self):
+        greendns.resolve = _make_mock_resolve()
+        greendns.resolve.add('example.com', '1.2.3.4')
+        res = greendns.getaddrinfo(b'example.com', b'0')
+        addr = [('1.2.3.4', 0)] * len(res)
+        assert addr == [ai[-1] for ai in res]
 
     def test_getaddrinfo_hosts_only_timeout(self):
         hostsres = _make_mock_base_resolver()


### PR DESCRIPTION
Python's getaddrinfo supports bytes as the host parameter, but greendns's getaddrinfo doesn't and fails with the following error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "eventlet/support/greendns.py", line 517, in getaddrinfo
    qname, addrs = _getaddrinfo_lookup(host, family, flags)
  File "eventlet/support/greendns.py", line 479, in _getaddrinfo_lookup
    answer = resolve(host, qfamily, False, use_network=use_network)
  File "eventlet/support/greendns.py", line 425, in resolve
    use_network=use_network)
  File "eventlet/support/greendns.py", line 380, in query
    return end()
  File "eventlet/support/greendns.py", line 359, in end
    raise result[1]
  File "eventlet/support/greendns.py", line 340, in step
    a = fun(*args, **kwargs)
  File "dns/resolver.py", line 858, in query
    if qname.is_absolute():
AttributeError: 'bytes' object has no attribute 'is_absolute'
```

We need to take into account when we receive bytes as the type of the host parameter and decode it.

Fix #599 