### PR TITLE
Remove unnecessary assignment in _recv_loop

### DIFF
--- a/eventlet/greenio/base.py
+++ b/eventlet/greenio/base.py
@@ -331,7 +331,6 @@ class GreenSocket(object):
             timeout_exc=socket_timeout('timed out'))
 
     def _recv_loop(self, recv_meth, empty_val, *args):
-        fd = self.fd
         if self.act_non_blocking:
             return recv_meth(*args)
 


### PR DESCRIPTION
In `_recv_loop` we assign `self.fd` to local variable `fd`, but then we don't use it within the method, so we can remove it.