### PR TITLE
tests: Fail on timeout when expect_pass=True

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -356,6 +356,9 @@ def run_python(path, env=None, args=None, timeout=None, pythonpath_extend=None, 
     except subprocess.TimeoutExpired:
         p.kill()
         output, _ = p.communicate(timeout=timeout)
+        if expect_pass:
+            sys.stderr.write('Program {0} output:\n---\n{1}\n---\n'.format(path, output.decode()))
+            assert False, 'timed out'
         return '{0}\nFAIL - timed out'.format(output).encode()
 
     if expect_pass:


### PR DESCRIPTION
Previously, a bunch of tests that just call `tests.run_isolated(...)` (such as those at the end of `patcher_test.py`) might time out but not actually show any errors.