### PR TITLE
Fixes for the test suite on SPARC

### DIFF
--- a/tests/greenio_test.py
+++ b/tests/greenio_test.py
@@ -925,7 +925,10 @@ def test_set_nonblocking():
     assert orig_flags & os.O_NONBLOCK == 0
     greenio.set_nonblocking(sock)
     new_flags = fcntl.fcntl(fileno, fcntl.F_GETFL)
-    assert new_flags == (orig_flags | os.O_NONBLOCK)
+    # on SPARC, O_NDELAY is set as well, and it might be a superset
+    # of O_NONBLOCK
+    assert (new_flags == (orig_flags | os.O_NONBLOCK)
+            or new_flags == (orig_flags | os.O_NONBLOCK | os.O_NDELAY))
 
 
 def test_socket_del_fails_gracefully_when_not_fully_initialized():

--- a/tests/greenio_test.py
+++ b/tests/greenio_test.py
@@ -634,7 +634,8 @@ class TestGreenSocket(tests.LimitedTestCase):
         sock1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         fd = sock1.fd.fileno()
         flags = fcntl.fcntl(fd, fcntl.F_GETFL)
-        flags = fcntl.fcntl(fd, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
+        fcntl.fcntl(fd, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
+        flags = fcntl.fcntl(fd, fcntl.F_GETFL)
         assert flags & os.O_NONBLOCK == 0
 
         sock2 = socket.socket(sock1.fd, set_nonblocking=False)

--- a/tests/greenio_test.py
+++ b/tests/greenio_test.py
@@ -634,13 +634,15 @@ class TestGreenSocket(tests.LimitedTestCase):
         sock1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         fd = sock1.fd.fileno()
         flags = fcntl.fcntl(fd, fcntl.F_GETFL)
-        fcntl.fcntl(fd, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
+        # on SPARC, nonblocking mode sets O_NDELAY as well
+        fcntl.fcntl(fd, fcntl.F_SETFL, flags & ~(os.O_NONBLOCK
+                                                 | os.O_NDELAY))
         flags = fcntl.fcntl(fd, fcntl.F_GETFL)
-        assert flags & os.O_NONBLOCK == 0
+        assert flags & (os.O_NONBLOCK | os.O_NDELAY) == 0
 
         sock2 = socket.socket(sock1.fd, set_nonblocking=False)
         flags = fcntl.fcntl(sock2.fd.fileno(), fcntl.F_GETFL)
-        assert flags & os.O_NONBLOCK == 0
+        assert flags & (os.O_NONBLOCK | os.O_NDELAY) == 0
 
     def test_sockopt_interface(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/tests/tpool_test.py
+++ b/tests/tpool_test.py
@@ -366,7 +366,7 @@ class TpoolLongTests(tests.LimitedTestCase):
 
 
 def test_isolate_from_socket_default_timeout():
-    tests.run_isolated('tpool_isolate_socket_default_timeout.py', timeout=1)
+    tests.run_isolated('tpool_isolate_socket_default_timeout.py', timeout=5)
 
 
 def test_exception_leak():


### PR DESCRIPTION
This PR combines 4 fixes needed for the test suite to pass on SPARC. Don't ask me why Linux kernel behaves so differently between architectures.

1. Fixes the test case wrongly assuming that `F_SETFL` will return flags. It always returns 0, so we need to call `F_GETFL` explicitly to verify the new flags. While this technically doesn't break anything (the `assert` always passes), the fix made it easier to figure out why the test was failing.
2. Fixes disabling non-blocking mode to unset `O_NDELAY` as well. Unsetting just `O_NONBLOCK` and leaving `O_NDELAY` didn't do anything on SPARC (the flags stayed as-is).
3. Fixes the assertion when setting non-blocking mode to assume that `O_NDELAY` may be set as well as `O_NONBLOCK`. This is what happens on SPARC.
4. Increases test timeout per #614. I'm not sure if this is the correct solution, or if the test needs a major refactoring but expecting it to pass under 1 second when it takes almost 2 seconds to import modules is impossible.