### PR TITLE
Fix misc SyntaxWarning's under Python 3.8

### DIFF
--- a/eventlet/db_pool.py
+++ b/eventlet/db_pool.py
@@ -75,7 +75,7 @@ class BaseConnectionPool(Pool):
 
         If max_age or max_idle is 0, _schedule_expiration likewise does nothing.
         """
-        if self.max_age is 0 or self.max_idle is 0:
+        if self.max_age == 0 or self.max_idle == 0:
             # expiration is unnecessary because all connections will be expired
             # on put
             return


### PR DESCRIPTION
Use '==' instead of 'is':

 eventlet/db_pool.py:78: SyntaxWarning: "is" with a literal. Did you mean "=="?
   if self.max_age is 0 or self.max_idle is 0: