### PR TITLE
greendns: Use _compute_times on dnspython 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,29 @@ matrix:
   include:
     - {python: 3.6, env: TOXENV=pep8}
 
-    - {python: 2.7, env: TOXENV=py27-epolls}
-    - {python: 2.7, env: TOXENV=py27-poll}
-    - {python: 2.7, env: TOXENV=py27-selects}
+    - {python: 2.7, env: TOXENV=py27-epolls-dnspython1}
+    - {python: 2.7, env: TOXENV=py27-poll-dnspython1}
+    - {python: 2.7, env: TOXENV=py27-selects-dnspython1}
 
-    - {python: 3.5, env: TOXENV=py35-epolls}
-    - {python: 3.5, env: TOXENV=py35-poll}
-    - {python: 3.5, env: TOXENV=py35-selects}
+    - {python: 3.5, env: TOXENV=py35-epolls-dnspython1}
+    - {python: 3.5, env: TOXENV=py35-poll-dnspython1}
+    - {python: 3.5, env: TOXENV=py35-selects-dnspython1}
 
-    - {python: 3.6, env: TOXENV=py36-epolls}
-    - {python: 3.6, env: TOXENV=py36-poll}
-    - {python: 3.6, env: TOXENV=py36-selects}
+    - {python: 3.6, env: TOXENV=py36-epolls-dnspython1}
+    - {python: 3.6, env: TOXENV=py36-poll-dnspython1}
+    - {python: 3.6, env: TOXENV=py36-selects-dnspython1}
 
-    - {python: 3.7, env: TOXENV=py37-epolls}
-    - {python: 3.7, env: TOXENV=py37-poll}
-    - {python: 3.7, env: TOXENV=py37-selects}
+    - {python: 3.7, env: TOXENV=py37-epolls-dnspython1}
+    - {python: 3.7, env: TOXENV=py37-poll-dnspython1}
+    - {python: 3.7, env: TOXENV=py37-selects-dnspython1}
 
-    - {python: 3.8, env: TOXENV=py38-epolls}
-    - {python: 3.8, env: TOXENV=py38-poll}
-    - {python: 3.8, env: TOXENV=py38-selects}
+    - {python: 3.8, env: TOXENV=py38-epolls-dnspython1}
+    - {python: 3.8, env: TOXENV=py38-poll-dnspython1}
+    - {python: 3.8, env: TOXENV=py38-selects-dnspython1}
+
+    - {python: 2.7, env: TOXENV=py36-selects-dnspython2}
+    - {python: 3.6, env: TOXENV=py36-selects-dnspython2}
+    - {python: 3.8, env: TOXENV=py38-selects-dnspython2}
 
     - {python: pypy, env: TOXENV=pypy-epolls}
     - {python: pypy, env: TOXENV=pypy-poll}

--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -118,6 +118,15 @@ def is_ip_addr(host):
     return is_ipv4_addr(host) or is_ipv6_addr(host)
 
 
+def compute_expiration(query, timeout):
+    # NOTE(ralonsoh): in dnspython v2.0.0, "_compute_expiration" was replaced
+    # by "_compute_times".
+    if hasattr(query, '_compute_expiration'):
+        return query._compute_expiration(timeout)
+    else:
+        return query._compute_times(timeout)[1]
+
+
 class HostsAnswer(dns.resolver.Answer):
     """Answer class for HostsResolver object"""
 
@@ -709,7 +718,7 @@ def udp(q, where, timeout=DNS_QUERY_TIMEOUT, port=53,
     s = socket.socket(af, socket.SOCK_DGRAM)
     s.settimeout(timeout)
     try:
-        expiration = dns.query._compute_expiration(timeout)
+        expiration = compute_expiration(dns.query, timeout)
         if source is not None:
             s.bind(source)
         while True:
@@ -802,7 +811,7 @@ def tcp(q, where, timeout=DNS_QUERY_TIMEOUT, port=53,
     s = socket.socket(af, socket.SOCK_STREAM)
     s.settimeout(timeout)
     try:
-        expiration = dns.query._compute_expiration(timeout)
+        expiration = compute_expiration(dns.query, timeout)
         if source is not None:
             s.bind(source)
         while True:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     url='http://eventlet.net',
     packages=setuptools.find_packages(exclude=['benchmarks', 'tests', 'tests.*']),
     install_requires=(
-        'dnspython >= 1.15.0, < 2.0.0',
+        'dnspython >= 1.15.0',
         'greenlet >= 0.3',
         'monotonic >= 1.4',
         'six >= 1.10.0',

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ statistics = 1
 [tox]
 minversion=2.5
 envlist =
-    ipv6, pep8, py{27,35,36,37,38,py}-{selects,poll,epolls}
+    ipv6, pep8, py{27,35,36,37,38,py}-{selects,poll,epolls}-dnspython{1,2}
 
 [testenv:ipv6]
 basepython = python
@@ -68,6 +68,8 @@ deps =
     py27-{selects,poll,epolls}: pyopenssl==17.3.0
     setuptools==38.5.1
     {selects,poll,epolls}: pyzmq==17.0.0
+    dnspython1: dnspython<2
+    dnspython2: dnspython>=2,<3
 commands =
     nosetests --verbose {env:tox_cover_args} {posargs:tests/}
     coverage xml -i


### PR DESCRIPTION
See https://github.com/rthalley/dnspython/commit/52f46fc0 for the dnspython change this is fixing.

Mostly fixes dnspython 2, except minor failures. c.f. https://github.com/eventlet/eventlet/issues/619