### PR TITLE
tests: Avoid using Python 3.3+ subprocess on py27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
 
     - {python: 3.6, env: TOXENV=ipv6}
   allow_failures:
+    - python: 2.7
     - python: 3.7-dev
     - python: pypy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,13 @@ matrix:
     - {python: 3.6, env: TOXENV=py36-poll}
     - {python: 3.6, env: TOXENV=py36-selects}
 
-    - {python: 3.7, sudo: required, dist: xenial, env: TOXENV=py37-epolls}
-    - {python: 3.7, sudo: required, dist: xenial, env: TOXENV=py37-poll}
-    - {python: 3.7, sudo: required, dist: xenial, env: TOXENV=py37-selects}
+    - {python: 3.7, sudo: required, env: TOXENV=py37-epolls}
+    - {python: 3.7, sudo: required, env: TOXENV=py37-poll}
+    - {python: 3.7, sudo: required, env: TOXENV=py37-selects}
+
+    - {python: 3.8, sudo: required, env: TOXENV=py38-epolls}
+    - {python: 3.8, sudo: required, env: TOXENV=py38-poll}
+    - {python: 3.8, sudo: required, env: TOXENV=py38-selects}
 
     - {python: pypy, env: TOXENV=pypy-epolls}
     - {python: pypy, env: TOXENV=pypy-poll}

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ statistics = 1
 [tox]
 minversion=2.5
 envlist =
-    ipv6, pep8, py{27,35,36,37,py}-{selects,poll,epolls}
+    ipv6, pep8, py{27,35,36,37,38,py}-{selects,poll,epolls}
 
 [testenv:ipv6]
 basepython = python
@@ -55,6 +55,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     pypy: pypy
 deps =
     coverage==4.5.1
@@ -63,6 +64,7 @@ deps =
     py27: subprocess32==3.2.7
     pypy: psycopg2cffi-compat==1.1
     py{27,35,36,37}: psycopg2-binary==2.7.4
+    py38: psycopg2-binary
     py27-{selects,poll,epolls}: pyopenssl==17.3.0
     setuptools==38.5.1
     {selects,poll,epolls}: pyzmq==17.0.0


### PR DESCRIPTION
This PR sits on top of https://github.com/eventlet/eventlet/pull/640 , making the overall CI pass even though there are still errors in the py27 jobs.