### PR TITLE
Clean up TypeError in __del__

### DIFF
--- a/eventlet/greenio/py2.py
+++ b/eventlet/greenio/py2.py
@@ -207,7 +207,10 @@ class _SocketDuckForFd(object):
         was_closed = self._mark_as_closed()
         if was_closed:
             return
-        notify_close(self._fileno)
+        if notify_close:
+            # If closing from __del__, notify_close may have
+            # already been cleaned up and set to None
+            notify_close(self._fileno)
         try:
             os.close(self._fileno)
         except:


### PR DESCRIPTION
At the end of the py2 tests, we would see (ignored) errors like

    Exception TypeError: "'NoneType' object is not callable" in <bound method _SocketDuckForFd.__del__ of _SocketDuckForFd:14> ignored