### PR TITLE
ssl: context wrapped listener failed to supply _context in accept()

### DIFF
--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -404,14 +404,11 @@ class GreenSSLSocket(_original_sslsocket):
 
         new_ssl = type(self)(
             newsock,
-            keyfile=self.keyfile,
-            certfile=self.certfile,
             server_side=True,
-            cert_reqs=self.cert_reqs,
-            ssl_version=self.ssl_version,
-            ca_certs=self.ca_certs,
             do_handshake_on_connect=False,
-            suppress_ragged_eofs=self.suppress_ragged_eofs)
+            suppress_ragged_eofs=self.suppress_ragged_eofs,
+            _context=self._context,
+        )
         return (new_ssl, addr)
 
     def dup(self):


### PR DESCRIPTION
https://github.com/eventlet/eventlet/issues/651

Seems correct, but could potentially break a lot of code, so calling for extensive public testing.

`pip install -U https://github.com/eventlet/eventlet/archive/i651.zip` and try to run your software.