### PR TITLE
travis: update according to their validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-sudo: required
+os: linux
+dist: xenial
 language: python
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - {python: 3.6, env: TOXENV=pep8}
@@ -64,6 +65,3 @@ script:
 after_failure:
   - for X in .tox/$TOXENV/log/*; do echo "$X\n"; cat "$X"; echo "\n\n"; done
   - echo "pip.log\n"; cat $HOME/.pip/pip.log
-
-notifications:
-  slack: eventlet-net:OYrQ1JE3hdTD78yQY1yZJnnc


### PR DESCRIPTION
- deprecated key sudo (The key `sudo` has no effect anymore.)
- missing os/dist
- key matrix is an alias for jobs, using jobs
- eventlet slack channel was abandoned