### PR TITLE
doc index: (mostly) remove dead links

### DIFF
--- a/doc/real_index.html
+++ b/doc/real_index.html
@@ -65,18 +65,6 @@ eventlet==x.y</pre></code></p>
 </ul>
 
 
-<h3>Discussion</h3>
-
-<ul>
-<li>
-  <p><a class="reference external" target="_blank" href="https://lists.secondlife.com/cgi-bin/mailman/listinfo/eventletdev">eventletdev at lists.secondlife.com</a></p>
-  <p>This is a low traffic list about using and developing Eventlet. Look through the <a class="reference external" target="_blank" href="https://lists.secondlife.com/pipermail/eventletdev/">archives</a> for some useful information and possible answers to questions.</p>
-</li>
-<li>There's an IRC channel dedicated to Eventlet: <a class="reference external" target="_blank" href="irc://kubrick.freenode.net/#eventlet">#eventlet on freenode</a>.  It's a pretty chill place to hang out!</li>
-<li>We have <a class="reference external" target="_blank" href="https://plus.google.com/communities/102444398246193806164">Eventlet Google+ Community</a>. Join us, +1, share your ideas, report bugs, find new friends or even new job!</li>
-</ul>
-
-
 <h3>Development</h3>
 
 <p>Development, issue tracking happens at <a class="reference" target="_blank" href="https://github.com/eventlet/eventlet/">Eventlet on Github</a></p>
@@ -105,12 +93,9 @@ links to related issues or websites
 
 <p>Please be sure to report bugs <a class="reference external" target="_blank" href="http://www.chiark.greenend.org.uk/~sgtatham/bugs.html">as effectively as possible</a>, to ensure that we understand and act on them quickly.</p>
 
-<p>You may report bugs via:
-<ol>
-  <li><a class="reference external" target="_blank" href="https://github.com/eventlet/eventlet/issues/new">Github</a></li>
-  <li><a class="reference external" target="_blank" href="https://bitbucket.org/eventlet/eventlet/issues/new/">Bitbucket</a> (no registration is required)</li>
-  <li><a class="reference external" target="_blank" href="mailto:eventletdev@lists.secondlife.com">Email eventletdev@lists.secondlife.com</a></li>
-</ol>
+<p>Usually <a class="reference external" target="_blank" href="https://github.com/eventlet/eventlet/issues/new">open issue at Github</a></p>
+
+<p>In special cases, to contact current maintainers directly, look up info on Github project page.</p>
 
 
 <div class="section" id="web-crawler-example">
@@ -139,18 +124,11 @@ for body in pool.imap(fetch, urls):
 </code></pre>
 
 
-<h3>Stats</h3>
-<p><a class="reference external" target="_blank" href="https://travis-ci.org/eventlet/eventlet"><img alt="Travis build" src="https://travis-ci.org/eventlet/eventlet.svg?branch=master"></a></p>
-
-<!--
-Here we insert Ohloh Project Basic Stats widget.
-<script src="http://www.ohloh.net/p/480234/widgets/project_basic_stats.js"></script>
-
-Unfortunately, they use blocking javascript with document.write() which is a bit unacceptable.
-So instead I inserted the result of javascript write. It's not public API, so it may break in future.
-In case iframe is broken, try visiting script again and copy updated html from there.
--->
-<iframe src="http://www.ohloh.net/p/480234/widgets/project_basic_stats.html" scrolling="no" marginHeight=0 marginWidth=0 style="height: 225px; width: 350px; border: none;"></iframe>
+<h3>Flair</h3>
+<p>
+  <a class="reference external" target="_blank" href="https://travis-ci.org/eventlet/eventlet" rel="nofollow"><img alt="Travis build" src="https://travis-ci.org/eventlet/eventlet.svg?branch=master"></a>
+  <a class="reference external" target="_blank" href="https://codecov.io/gh/eventlet/eventlet" rel="nofollow"><img alt="Codecov coverage" src="https://codecov.io/gh/eventlet/eventlet/branch/master/graph/badge.svg?token=k01TsER6fy"></a>
+</p>
 </div>
 </div>
 </div>
@@ -167,13 +145,9 @@ In case iframe is broken, try visiting script again and copy updated html from t
 <ul>
 <li><a class="reference external" href="doc/">Documentation</a></li>
 <li><a class="reference external" href="doc/changelog.html">Changelog</a></li>
-<li><a class="reference external" target="_blank" href="https://plus.google.com/communities/102444398246193806164">Google+ community</a></li>
 <li><a class="reference external" target="_blank" href="https://github.com/eventlet/eventlet/">Eventlet on Github</a></li>
-<li><a class="reference external" target="_blank" href="https://bitbucket.org/eventlet/eventlet/">Eventlet on Bitbucket</a></li>
-<li><a class="reference external" target="_blank" href="https://lists.secondlife.com/pipermail/eventletdev/">Mailing List Archives</a></li>
-<li><a class="reference external" target="_blank" href="http://build.eventlet.net/">Automated Builds</a></li>
 <li><a class="reference external" target="_blank" href="irc://chat.freenode.net/#eventlet">IRC channel</a></li>
-<li><a class="reference external" target="_blank" href="http://blog.eventlet.net/">Blog (archive)</a></li>
+<li><a class="reference external" target="_blank" href="https://www.openhub.net/p/eventlet">Open Hub stats</a></li>
 </ul>
         </div>
       </div>


### PR DESCRIPTION
Eventlet channel on Freenode IRC is probably still alive, so I left it in bottom links list, but it's also probably ghost, so removed whole Discussion section, every other communication was dead for a while now.