### PR TITLE
py39: Add _at_fork_reinit method to Semaphores

### DIFF
--- a/eventlet/semaphore.py
+++ b/eventlet/semaphore.py
@@ -39,6 +39,7 @@ class Semaphore(object):
         if value < 0:
             msg = 'Semaphore() expect value >= 0, actual: {0}'.format(repr(value))
             raise ValueError(msg)
+        self._original_value = value
         self.counter = value
         self._waiters = collections.deque()
 
@@ -50,6 +51,10 @@ class Semaphore(object):
     def __str__(self):
         params = (self.__class__.__name__, self.counter, len(self._waiters))
         return '<%s c=%s _w[%s]>' % params
+
+    def _at_fork_reinit(self):
+        self.counter = self._original_value
+        self._waiters.clear()
 
     def locked(self):
         """Returns true if a call to acquire would block.


### PR DESCRIPTION
CPython expects to be able to call such a method on `RLock`s, `Condition`s, and `Event`s in `threading`; since we may monkey-patch `threading` to use `Semaphore`s as locks, they need the method, too.

Addresses #646