### PR TITLE
Deprecate CPython 2.7 and 3.4 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,10 @@ If you have a project that uses Eventlet with Twisted, your options are:
 
 Apologies for any inconvenience.
 
+Supported Python versions
+=========================
+
+Currently CPython 2.7 and 3.4+ are supported, but **2.7 and 3.4 support is deprecated and will be removed in the future**, only CPython 3.5+ support will remain.
 
 Flair
 =====

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,6 +21,12 @@ Code talks!  This is a simple web crawler that fetches a bunch of urls concurren
     for body in pool.imap(fetch, urls):
         print("got body", len(body))
 
+Supported Python versions
+=========================
+
+Currently CPython 2.7 and 3.4+ are supported, but **2.7 and 3.4 support is deprecated and will be removed in the future**, only CPython 3.5+ support will remain.
+
+
 Contents
 =========
 

--- a/doc/real_index.html
+++ b/doc/real_index.html
@@ -39,6 +39,8 @@
 
 <p>License: <a class="reference external" target="_blank" href="https://opensource.org/licenses/MIT">MIT</a></p>
 
+<p>Currently CPython 2.7 and 3.4+ are supported, but <strong>2.7 and 3.4 support is deprecated and will be removed in the future</strong>, only CPython 3.5+ support will remain.</p>
+
 <h3><a href="doc/">API Documentation</a></h3>
 
 

--- a/eventlet/__init__.py
+++ b/eventlet/__init__.py
@@ -1,5 +1,12 @@
 import os
+import sys
+import warnings
 
+if sys.version_info < (3, 5):
+    warnings.warn(
+        "Support for your Python version is deprecated and will be removed in the future",
+        DeprecationWarning,
+    )
 
 version_info = (0, 29, 1)
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
This will allow us to remove some code and better spend the available
resources. Both 2.7 and 3.4 are EOL.

Closes GH-623.