### PR TITLE
pyopenssl tsafe module was deprecated and removed in v20.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ jobs:
     - {python: pypy, env: TOXENV=pypy-selects}
 
     - {python: 3.6, env: TOXENV=ipv6}
+    - {python: 3.8, env: TOXENV=py38-openssl}
   allow_failures:
     - python: 3.7-dev
     - python: pypy

--- a/eventlet/green/OpenSSL/__init__.py
+++ b/eventlet/green/OpenSSL/__init__.py
@@ -1,4 +1,9 @@
 from . import crypto
 from . import SSL
-from . import tsafe
+try:
+    # pyopenssl tsafe module was deprecated and removed in v20.0.0
+    # https://github.com/pyca/pyopenssl/pull/913
+    from . import tsafe
+except ImportError:
+    pass
 from .version import __version__

--- a/tests/openssl_test.py
+++ b/tests/openssl_test.py
@@ -12,5 +12,4 @@ def test_import():
 
     import eventlet.green.OpenSSL.SSL
     import eventlet.green.OpenSSL.crypto
-    import eventlet.green.OpenSSL.tsafe
     import eventlet.green.OpenSSL.version

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ statistics = 1
 [tox]
 minversion=2.5
 envlist =
-    ipv6, pep8, py{27,35,36,37,38,py}-{selects,poll,epolls}
+    ipv6, pep8, py{27,35,36,37,38,py}-{selects,poll,epolls}, py38-openssl
 
 [testenv:ipv6]
 basepython = python
@@ -65,6 +65,7 @@ deps =
     pypy: psycopg2cffi-compat==1.1
     py{27,35,36,37}: psycopg2-binary==2.7.4
     py38: psycopg2-binary==2.8.4
+    py38-openssl: pyopenssl==20.0.0
     py27-{selects,poll,epolls}: pyopenssl==17.3.0
     setuptools==38.5.1
     {selects,poll,epolls}: pyzmq==17.0.0


### PR DESCRIPTION
I believe change is backward compatible.

Upstream news: https://github.com/pyca/pyopenssl/pull/913
Problem report: https://github.com/eventlet/eventlet/issues/671
