### PR TITLE
greendns: Patch ssl

### DIFF
--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -42,6 +42,7 @@ from eventlet.green import _socket_nodns
 from eventlet.green import os
 from eventlet.green import time
 from eventlet.green import select
+from eventlet.green import ssl
 import six
 
 
@@ -55,6 +56,7 @@ def import_patched(module_name):
         'time': time,
         'os': os,
         'socket': _socket_nodns,
+        'ssl': ssl,
     }
     return patcher.import_patched(module_name, **modules)
 


### PR DESCRIPTION
Newer (2.0+) `dnspython` [imports `ssl`](https://github.com/rthalley/dnspython/blob/v2.0.0/dns/query.py#L48) (and [`requests`](https://github.com/rthalley/dnspython/blob/v2.0.0/dns/query.py#L40), which would have eventually imported `ssl`), so `greendns` needs a monkey-patched `ssl`, too. This should prevent a `RecursionError` with `SSLContext`.

Note that this *does not* bring full `dnspython>=2.0` support, but our version pin hasn't stopped people from trying to run with newer `dnspython` anyway. May as well make it hurt a little less.

Fixes #677, but see also #619.