### PR TITLE
Set suppress_ragged_eofs default based on SSLSocket defaults

### DIFF
--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -70,7 +70,7 @@ class GreenSSLSocket(_original_sslsocket):
                         sock=sock.fd,
                         server_side=server_side,
                         do_handshake_on_connect=False,
-                        suppress_ragged_eofs=kw.get('suppress_ragged_eofs'),
+                        suppress_ragged_eofs=kw.get('suppress_ragged_eofs', True),
                         server_hostname=kw.get('server_hostname'),
                         context=context,
                         session=kw.get('session'),


### PR DESCRIPTION
I have an HTTPS connection that required Connection: close to be sent in the header and it was closing as soon as the data was sent. I cannot post the server URL, but it was raising the below error:

```
Exception has occurred: SSLError
EOF occurred in violation of protocol (_ssl.c:2570)
  File "C:\Users\allisree\Envs\ami37\Lib\site-packages\urllib3\response.py", line 449, in _error_catcher
    raise SSLError(e)
  File "C:\Program Files\Python37\Lib\contextlib.py", line 130, in __exit__
    self.gen.throw(type, value, traceback)
  File "C:\Users\allisree\Envs\ami37\Lib\site-packages\urllib3\response.py", line 541, in read
    raise IncompleteRead(self._fp_bytes_read, self.length_remaining)
  File "C:\Users\allisree\Envs\ami37\Lib\site-packages\urllib3\response.py", line 576, in stream
    data = self.read(amt=amt, decode_content=decode_content)
  File "C:\Users\allisree\Envs\ami37\Lib\site-packages\requests\models.py", line 753, in generate
    for chunk in self.raw.stream(chunk_size, decode_content=True):
  File "C:\Users\allisree\Envs\ami37\Lib\site-packages\requests\models.py", line 831, in content
    self._content = b''.join(self.iter_content(CONTENT_CHUNK_SIZE)) or b''
  File "C:\Users\allisree\Envs\ami37\Lib\site-packages\requests\sessions.py", line 697, in send
    r.content
  File "C:\Users\allisree\Envs\ami37\Lib\site-packages\requests\sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "C:\Users\allisree\Envs\ami37\Lib\site-packages\requests\api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "C:\Users\allisree\Envs\ami37\Lib\site-packages\requests\api.py", line 119, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "C:\Users\allisree\Downloads\test.py", line 15, in <module>
    r = requests.post('https://myurl.com', headers=headers, data=data)
```

This is a result of `suppress_ragged_eofs` defaulting to True in `SSLSocket`, but defaulting to None in `GreenSSLSocket` when monkey_patched. This only occurs in Python 3.7+.