### PR TITLE
tests: extend default mysqldb test timeout to 5s

### DIFF
--- a/tests/mysqldb_test.py
+++ b/tests/mysqldb_test.py
@@ -38,6 +38,8 @@ def mysql_requirement(_f):
 
 
 class TestMySQLdb(tests.LimitedTestCase):
+    TEST_TIMEOUT = 5
+
     def setUp(self):
         self._auth = get_database_auth()['MySQLdb']
         self.create_db()


### PR DESCRIPTION
@tipabu sorry, you were right, there is something wrong with mysqldb tests after all.