### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/eventlet/zipkin/client.py
+++ b/eventlet/zipkin/client.py
@@ -15,7 +15,7 @@ class ZipkinClient(object):
 
     def __init__(self, host='127.0.0.1', port=9410):
         """
-        :param host: zipkin collector IP addoress (default '127.0.0.1')
+        :param host: zipkin collector IP address (default '127.0.0.1')
         :param port: zipkin collector port (default 9410)
         """
         self.host = host

--- a/tests/hub_test.py
+++ b/tests/hub_test.py
@@ -362,7 +362,7 @@ class TestDeadRunLoop(tests.LimitedTestCase):
         # kill dummyproc, this schedules a timer to return execution to
         # this greenlet before throwing an exception in dummyproc.
         # it is from this timer that execution should be returned to this
-        # greenlet, and not by propogating of the terminating greenlet.
+        # greenlet, and not by propagating of the terminating greenlet.
         g.kill()
         with eventlet.Timeout(0.5, self.CustomException()):
             # we now switch to the hub, there should be no existing timers

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -397,7 +397,7 @@ class TestHttpd(_TestBase):
         # Eventlet issue: "Python 3: wsgi doesn't handle correctly partial
         # write of socket send() when using writelines()".
         #
-        # The bug was caused by the default writelines() implementaiton
+        # The bug was caused by the default writelines() implementation
         # (used by the wsgi module) which doesn't check if write()
         # successfully completed sending *all* data therefore data could be
         # lost and the client could be left hanging forever.


### PR DESCRIPTION
There are small typos in:
- eventlet/zipkin/client.py
- tests/hub_test.py
- tests/wsgi_test.py

Fixes:
- Should read `propagating` rather than `propogating`.
- Should read `implementation` rather than `implementaiton`.
- Should read `address` rather than `addoress`.

Closes #710