### PR TITLE
Only wrap socket.timeout on Python < 3.10

### DIFF
--- a/eventlet/greenio/base.py
+++ b/eventlet/greenio/base.py
@@ -29,7 +29,10 @@ if six.PY2:
 _original_socket = eventlet.patcher.original('socket').socket
 
 
-socket_timeout = eventlet.timeout.wrap_is_timeout(socket.timeout)
+if sys.version_info >= (3, 10):
+    socket_timeout = socket.timeout  # Really, TimeoutError
+else:
+    socket_timeout = eventlet.timeout.wrap_is_timeout(socket.timeout)
 
 
 def socket_connect(descriptor, address):


### PR DESCRIPTION
On py310, socket.timeout is TimeoutError, which our is_timeout() helper func already knows is a timeout.

Closes #687

Note that this doesn't get us to py310 support (not by a long shot), but it's a step along the way. In particular, you'll get

    AttributeError: 'staticmethod' object has no attribute '__code__'

trying to call `six.get_function_code(_original_pyio.open)` in eventlet/greenio/py3.py

This seems to be because of the resolution to https://bugs.python.org/issue43680

