### PR TITLE
Fixed wrap_socket missing ciphers parameter bug.

### DIFF
--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -85,6 +85,7 @@ class GreenSSLSocket(_original_sslsocket):
                         ssl_version=ssl_version,
                         ca_certs=ca_certs,
                         do_handshake_on_connect=False,
+                        ciphers=kw.get('ciphers'),
                     )
             ret.keyfile = keyfile
             ret.certfile = certfile


### PR DESCRIPTION
Fixe bugs : #717 

ssl wrap_socket missing ciphers paramter leading the ciphers configuration does not works.


