### PR TITLE
"/etc/resolv.conf" assumed default path is wrong for termux

### DIFF
--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -408,7 +408,24 @@ class ResolverProxy(object):
         return aliases
 
 
-resolver = ResolverProxy(hosts_resolver=HostsResolver())
+"""
+Some systems' default resolv.conf file is not located in /etc/resolv.conf
+
+for instance, in termux (terminal app in android) there are system configurations wich can not
+be mounted or symbolically linked to the android's /etc/ path, due to how android works
+and therefore have their own locations in a subdirectory in the app's data directory
+
+the termux environment can be identified via the $PREFIX environment variable, and so
+the following code provides a patch for this specific case, while maintaining the default 
+functionality if the system is not termux
+"""
+resolver = None
+if 'PREFIX' in os.environ and os.environ['PREFIX']=='/data/data/com.termux/files/usr':
+    print('greendns: system is termux')
+    resolver = ResolverProxy(hosts_resolver=HostsResolver(),filename=(os.environ['PREFIX']+'/etc/resolv.conf'))
+else:
+    resolver = ResolverProxy(hosts_resolver=HostsResolver())
+
 
 
 def resolve(name, family=socket.AF_INET, raises=True, _proxy=None,


### PR DESCRIPTION
termux: the default path for resolv.conf file is not "/etc/resolv.conf", but the code presumes that to be the case

termux is a terminal app for android capable of running many linux utilites

the file resolv.conf is not found at the default location which therefore breaks other projects which use this one as a dependency

i ran accross this problem when trying to run the termux version of onionshare (https://github.com/oleanderxoxo/onidroid) which uses this library as a dependency somewhere downstream

i'm not sure what would be the most elegant solution to the resolv.conf location problem, but i've tested this code, and it works as a quickfix nonetheless

it checks if the $PREFIX environment variable is set and if it points to the termux app's "...data/files/usr" system path, then specifies explicitly the location of the resolv.conf file when creating the resolver object, which needs to be $PREFIX + "/etc/resolv.conf"