### PR TITLE
Fix GreenSSLContext to handle minimum_version and maxmimum_version

### DIFF
--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -465,6 +465,15 @@ if hasattr(__ssl, 'SSLContext'):
             def verify_mode(self, value):
                 super(_original_sslcontext, _original_sslcontext).verify_mode.__set__(self, value)
 
+            if hasattr(_original_sslcontext, 'maximum_version'):
+                @_original_sslcontext.maximum_version.setter
+                def maximum_version(self, value):
+                    super(_original_sslcontext, _original_sslcontext).maximum_version.__set__(self, value)
+
+                @_original_sslcontext.minimum_version.setter
+                def minimum_version(self, value):
+                    super(_original_sslcontext, _original_sslcontext).minimum_version.__set__(self, value)
+
     SSLContext = GreenSSLContext
 
     if hasattr(__ssl, 'create_default_context'):

--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -465,11 +465,12 @@ if hasattr(__ssl, 'SSLContext'):
             def verify_mode(self, value):
                 super(_original_sslcontext, _original_sslcontext).verify_mode.__set__(self, value)
 
-            if hasattr(_original_sslcontext, 'maximum_version'):
+            if hasattr(_original_sslcontext, "maximum_version"):
                 @_original_sslcontext.maximum_version.setter
                 def maximum_version(self, value):
                     super(_original_sslcontext, _original_sslcontext).maximum_version.__set__(self, value)
 
+            if hasattr(_original_sslcontext, "minimum_version"):
                 @_original_sslcontext.minimum_version.setter
                 def minimum_version(self, value):
                     super(_original_sslcontext, _original_sslcontext).minimum_version.__set__(self, value)

--- a/tests/isolated/ssl_context_version_setters.py
+++ b/tests/isolated/ssl_context_version_setters.py
@@ -1,0 +1,12 @@
+__test__ = False
+
+if __name__ == "__main__":
+    import eventlet
+    eventlet.monkey_patch()
+    import ssl
+
+    context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    context.maximum_version = ssl.TLSVersion.TLSv1_2
+
+    print("pass")

--- a/tests/ssl_test.py
+++ b/tests/ssl_test.py
@@ -395,3 +395,7 @@ class SSLTest(tests.LimitedTestCase):
         client.send(b"check_hostname works")
         client.recv(64)
         server_coro.wait()
+
+    @tests.skip_if(sys.version_info < (3, 7))
+    def test_context_version_setters(self):
+        tests.run_isolated("ssl_context_version_setters.py")


### PR DESCRIPTION
Resolves #726 

Updates the GreenSSLContext object to provide setters for minimum_version and maximum_version properties to avoid RecursionError problems.