### PR TITLE
setup.cfg: Replace dashes with underscores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [wheel]
 universal = True


### PR DESCRIPTION
Setuptools v54.1.0 introduces a warning that the use of dash-separated options in 'setup.cfg' will not be supported in a future version. https://github.com/pypa/setuptools/commit/a2e9ae4cb
Get ahead of the issue by replacing the dashes with underscores. Without this, we see 'UserWarning' messages like the following on new enough versions of setuptools:

> UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead