### PR TITLE
ci: remove redundant basepython decls from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,15 +52,6 @@ setenv =
     poll: EVENTLET_HUB = poll
     epolls: EVENTLET_HUB = epolls
     tox_cover_args = --with-coverage --cover-erase --cover-package=eventlet
-basepython =
-    py27: python2.7
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
-    py38: python3.8
-    py39: python3.9
-    pypy2: pypy2
-    pypy3: pypy3
 deps =
     coverage==4.5.1
     nose==1.3.7


### PR DESCRIPTION
Remove basepython declarations from tox.ini where they match what tox
already infers from the environment name.  This is NFC for existing
testenvs, and it makes it possible to run tests on newer Python targets,
e.g. py310-*.