### PR TITLE
subsystem: fix bug:write a file with 'a' raise error

### DIFF
--- a/eventlet/greenio/py3.py
+++ b/eventlet/greenio/py3.py
@@ -71,41 +71,6 @@ class GreenFileIO(_OriginalIOBase):
         return 'r' in self._mode or '+' in self._mode
 
     def writable(self):
-        """judge file can write or not
-
-        >>> from eventlet.green import os
-        >>> from os import O_CREAT, O_APPEND, O_RDWR,O_TRUNC
-        >>> def read_file(filepath):
-        ...     with open(filepath,'r') as fr:
-        ...         return fr.read()
-        ...
-        >>> filepath = './1.txt'
-        >>> expected = "Write to file with mode 'w'."
-        >>> with os.fdopen(os.open(filepath, O_RDWR | O_CREAT | O_TRUNC, 0o777), 'w') as fw:
-        ...     i=fw.write(expected)
-        ...
-        >>> read_file(filepath)
-        "Write to file with mode 'w'."
-        >>> read_file(filepath) == expected
-        True
-
-        >>> read_file(filepath) == expected
-        True
-        >>> expected_2 = "Write to file with mode 'a'."
-        >>> with os.fdopen(os.open(filepath, O_RDWR | O_CREAT | O_APPEND, 0o777), 'a') as fa:
-        ...     i=fa.write(expected_2)
-        ...
-
-        >>> read_file(filepath) == expected+expected_2
-        True
-        >>> fw = os.fdopen(os.open(filepath, O_RDWR | O_CREAT | O_TRUNC, 0o777), 'r')
-        >>> fw.write(expected)
-        Traceback (most recent call last):
-            ...
-        io.UnsupportedOperation: not writable
-        >>> import os as sys_os
-        >>> sys_os.remove(filepath)
-        """
         return 'w' in self._mode or '+' in self._mode or 'a' in self._mode
 
     def fileno(self):

--- a/eventlet/greenio/py3.py
+++ b/eventlet/greenio/py3.py
@@ -71,7 +71,42 @@ class GreenFileIO(_OriginalIOBase):
         return 'r' in self._mode or '+' in self._mode
 
     def writable(self):
-        return 'w' in self._mode or '+' in self._mode
+        """judge file can write or not
+
+        >>> from eventlet.green import os
+        >>> from os import O_CREAT, O_APPEND, O_RDWR,O_TRUNC
+        >>> def read_file(filepath):
+        ...     with open(filepath,'r') as fr:
+        ...         return fr.read()
+        ...
+        >>> filepath = './1.txt'
+        >>> expected = "Write to file with mode 'w'."
+        >>> with os.fdopen(os.open(filepath, O_RDWR | O_CREAT | O_TRUNC, 0o777), 'w') as fw:
+        ...     i=fw.write(expected)
+        ...
+        >>> read_file(filepath)
+        "Write to file with mode 'w'."
+        >>> read_file(filepath) == expected
+        True
+
+        >>> read_file(filepath) == expected
+        True
+        >>> expected_2 = "Write to file with mode 'a'."
+        >>> with os.fdopen(os.open(filepath, O_RDWR | O_CREAT | O_APPEND, 0o777), 'a') as fa:
+        ...     i=fa.write(expected_2)
+        ...
+
+        >>> read_file(filepath) == expected+expected_2
+        True
+        >>> fw = os.fdopen(os.open(filepath, O_RDWR | O_CREAT | O_TRUNC, 0o777), 'r')
+        >>> fw.write(expected)
+        Traceback (most recent call last):
+            ...
+        io.UnsupportedOperation: not writable
+        >>> import os as sys_os
+        >>> sys_os.remove(filepath)
+        """
+        return 'w' in self._mode or '+' in self._mode or 'a' in self._mode
 
     def fileno(self):
         return self._fileno

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -488,3 +488,9 @@ def dns_tcp_server(ip_to_give, request_count=1):
     client.close()
     thread.join()
     server_socket.close()
+
+
+def read_file(path, mode="rb"):
+    with open(path, mode) as f:
+        result = f.read()
+    return result

--- a/tests/greenio_test.py
+++ b/tests/greenio_test.py
@@ -1024,54 +1024,40 @@ def test_pipe_context():
     assert r.closed and w.closed
 
 
-def read_file(filepath):
-    with open(filepath, 'r') as fr:
-        result = fr.read()
-    return result
+def test_greenpipe_write():
+    expected = b"initial"
+    with tempfile.NamedTemporaryFile() as f:
+        with greenio.GreenPipe(f.name, "wb") as writer:
+            writer.write(expected)
+
+        actual = tests.read_file(f.name)
+        assert actual == expected
 
 
-class TestGreenFileIO(tests.LimitedTestCase):
-    @tests.skip_on_windows
-    def setUp(self):
-        super(self.__class__, self).setUp()
-        self.tempdir = tempfile.mkdtemp('_green_file_io_test')
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
-        super(self.__class__, self).tearDown()
-
-    def test_write(self):
-        filepath = os.path.join(self.tempdir, 'test_file_w.txt')
-        writer = greenio.GreenPipe(filepath, 'w')
-        excepted = "Test write to file with mode 'w'."
-        writer.write(excepted)
-        writer.close()
-
-        actual = read_file(filepath)
-        self.assertEqual(excepted, actual, msg='actual=%s,excepted=%s' % (actual, excepted))
-
-    def test_append(self):
-        filepath = os.path.join(self.tempdir, 'test_file_a.txt')
-        old_data = 'Exist data...\n'
-        with open(filepath, 'w')as fw:
+def test_greenpipe_append():
+    old_data = b"existing data..."
+    new_data = b"append with mode=a"
+    expected = old_data + new_data
+    with tempfile.NamedTemporaryFile() as f:
+        with open(f.name, "wb") as fw:
             fw.write(old_data)
-        writer = greenio.GreenPipe(filepath, 'a')
-        new_data = "Test write to file with mode 'a'."
-        writer.write(new_data)
-        writer.close()
 
-        excepted = old_data + new_data
-        actual = read_file(filepath)
-        self.assertEqual(excepted, actual, msg='actual=%s,excepted=%s' % (actual, excepted))
+        with greenio.GreenPipe(f.name, "ab") as writer:
+            writer.write(new_data)
 
-    def test_read_and_write(self):
-        filepath = os.path.join(self.tempdir, 'test_file_rw.txt')
-        with open(filepath, 'w'):
-            pass
-        writer = greenio.GreenPipe(filepath, 'r+')
-        excepted = "Test write to file with mode 'r+'."
-        writer.write(excepted)
-        writer.close()
+        actual = tests.read_file(f.name)
+        assert actual == expected
 
-        actual = read_file(filepath)
-        self.assertEqual(excepted, actual, msg='actual=%s,excepted=%s' % (actual, excepted))
+
+def test_greenpipe_read_overwrite():
+    old_data = b"existing data..."
+    new_data = b"overwrite with mode=r+"
+    with tempfile.NamedTemporaryFile() as f:
+        with greenio.GreenPipe(f.name, "wb") as writer:
+            writer.write(old_data)
+
+        with greenio.GreenPipe(f.name, "r+b") as writer:
+            writer.write(new_data)
+
+        actual = tests.read_file(f.name)
+        assert actual == new_data


### PR DESCRIPTION
subsystem: fix bug:use eventlet.green.fdopen() to write a file with 'a' mode but raise "io.UnsupportedOperation: File or stream is not writable." error.

detail: eventlet.greenio.py3.GreenFileIO.writable() add the case——write a file with 'a' mode,so it judge the is or not to write and return excepted result.
issue: https://github.com/eventlet/eventlet/issues/757