### PR TITLE
Fix leak of epoll file descriptors

### DIFF
--- a/eventlet/hubs/epolls.py
+++ b/eventlet/hubs/epolls.py
@@ -29,3 +29,7 @@ class Hub(poll.Hub):
 
     def do_poll(self, seconds):
         return self.poll.poll(seconds)
+
+    def __del__(self):
+        self.poll.close()
+

--- a/tests/hub_test.py
+++ b/tests/hub_test.py
@@ -402,3 +402,7 @@ def test_kqueue_unsupported():
     # https://github.com/eventlet/eventlet/issues/38
     # get_hub on windows broken by kqueue
     tests.run_isolated('hub_kqueue_unsupported.py')
+
+
+def test_epoll_fd_leak():
+    tests.run_isolated('hub_epoll_file_descriptor_leak.py')

--- a/tests/isolated/hub_epoll_file_descriptor_leak.py
+++ b/tests/isolated/hub_epoll_file_descriptor_leak.py
@@ -1,0 +1,62 @@
+__test__ = False
+
+if __name__ == '__main__':
+
+    import eventlet
+    from eventlet import hubs
+    import eventlet.hubs
+    import threading
+    import os
+    import gc
+
+    rfd, wfd = os.pipe()
+    reader = eventlet.greenio.py3.GreenPipe(rfd, "rb", buffering=2)
+
+    def epoll_count():
+        epoll_count = 0
+        for f in os.listdir("/proc/self/fd"):
+            try:
+                p = os.path.join("/proc/self/fd", f)
+                if os.readlink(p) == "anon_inode:[eventpoll]":
+                    epoll_count += 1
+            except:
+                pass
+        return epoll_count
+
+    def fun(fd):
+        # separate trampoline may trigger additional bugs with multiple
+        # listeners
+        hubs.trampoline(fd, write=True)
+
+        with eventlet.greenio.py3.GreenPipe(fd, "wb", buffering=0) as w:
+            w.write(b"12")
+
+
+        # it would be wasteful to drop and recreate hub state every time
+        # all listeners stop
+        epolls = epoll_count()
+        assert epolls == 2, ('epoll file descriptor closed while it might '
+            'still be used. Currently having {}'.format(epolls))
+
+        hubs._threadlocal.hub.abort(wait=True)
+
+        # this makes it work
+        #hubs._threadlocal.hub.__del__()
+        # this one does not help
+        #del hubs._threadlocal.hub
+
+    t = threading.Thread(target=fun, args=(wfd,))
+    t.start()
+
+    assert reader.read(2) == b"12"
+    reader.close()
+
+    t.join()
+
+    # we need to ignore one FD here, since that is the one of the current
+    # thread (which is fine to exist)
+    epolls = epoll_count()
+    assert epolls == 1, '{} epoll file descriptor leaked'.format(
+        epolls - 1)
+
+    print('pass')


### PR DESCRIPTION
When a python process creates a new thread that uses an eventlet hub (e.g. when using `trampoline`) a new epoll file descriptor is allocated. If the thread now stops after a short amount of work the epoll file descriptor is not closed causing a leak.

If the python process (but not the thread) is long living and regularly spawns a lot of short-lived threads then this can cause an exhaustion of file descriptors.

To solve this the epoll file descriptor is now no longer allocated on hub creation but only when a listener is actually added. We also now close the file descriptor if there are no listeners left.