### PR TITLE
SSL socket should raise socket.timeout exception on timeout instead of SSLError

### DIFF
--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 
 orig_socket = __import__('socket')
 socket = orig_socket.socket
-timeout_exc = SSLError
+timeout_exc = orig_socket.timeout
 
 __patched__ = [
     'SSLSocket', 'SSLContext', 'wrap_socket', 'sslwrap_simple',


### PR DESCRIPTION
Back in Python 3.2, ssl.SSLError used to be a subclass of socket.error (see https://docs.python.org/3/library/ssl.html#exceptions), so timeouts on monkeypatched ssl sockets would be properly caught by socket.timeout exception handlers in applications.  However, since Python 3.3 ssl.SSLerror is a subclass of OSError, which signifies a different (typically fatal) type of error that is usually not handled gracefully by applications.

By changing the timeout exception back to socket.timeout, libraries such as pymysql and redis will again properly support TLS-connections in monkeypatched applications.

Fixes eventlet/eventlet#692