### PR TITLE
Fix tox error

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,9 @@ commands =
     pep8 benchmarks/ eventlet/ tests/
 
 [testenv]
-passenv = CI EVENTLET_DB_TEST_AUTH
+passenv =
+    CI
+    EVENTLET_DB_TEST_AUTH
 setenv =
     PYTHONDONTWRITEBYTECODE = 1
     selects: EVENTLET_HUB = selects


### PR DESCRIPTION
`tox>=4.0.0` changed `passenv` from a space-separated list to a comma-separated list. `tox>=4.0.6` made it a hard error to include spaces, complaining

    pass_env values cannot contain whitespace, use comma to have multiple values in a single line

Switch to using multiple lines for the multiple variables to be compatible with both tox3 and tox4.