### PR TITLE
chore: CI upgrades, pycodestyle fix 2 empty lines after class/def

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -10,10 +10,10 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/style.yaml') }}
@@ -21,7 +21,7 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
       - name: cache tox
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .tox
           key: ${{ runner.os }}-tox-style-${{ hashFiles('tox.ini') }}
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.x
       - name: install tox

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
   tox:
     name: "tox ${{ matrix.toxenv }}"
     continue-on-error: ${{ matrix.ignore-error }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012/5
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'eventlet/eventlet'
     timeout-minutes: 10
@@ -29,38 +29,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { py: 2.7, toxenv: py27-epolls, ignore-error: false }
-          - { py: 2.7, toxenv: py27-poll, ignore-error: false }
-          - { py: 2.7, toxenv: py27-selects, ignore-error: false }
-          - { py: 2.7, toxenv: py27-dnspython1, ignore-error: false }
-          - { py: 3.5, toxenv: py35-epolls, ignore-error: false }
-          - { py: 3.5, toxenv: py35-poll, ignore-error: false }
-          - { py: 3.5, toxenv: py35-selects, ignore-error: false }
-          - { py: 3.6, toxenv: py36-epolls, ignore-error: false }
-          - { py: 3.6, toxenv: py36-poll, ignore-error: false }
-          - { py: 3.6, toxenv: py36-selects, ignore-error: false }
-          - { py: 3.7, toxenv: py37-epolls, ignore-error: false }
-          - { py: 3.7, toxenv: py37-poll, ignore-error: false }
-          - { py: 3.7, toxenv: py37-selects, ignore-error: false }
-          - { py: 3.8, toxenv: py38-epolls, ignore-error: false }
-          - { py: 3.8, toxenv: py38-openssl, ignore-error: false }
-          - { py: 3.8, toxenv: py38-poll, ignore-error: false }
-          - { py: 3.8, toxenv: py38-selects, ignore-error: false }
-          - { py: 3.9, toxenv: py39-epolls, ignore-error: false }
-          - { py: 3.9, toxenv: py39-poll, ignore-error: false }
-          - { py: 3.9, toxenv: py39-selects, ignore-error: false }
-          - { py: 3.9, toxenv: py39-dnspython1, ignore-error: false }
-          - { py: 3.x, toxenv: ipv6, ignore-error: false }
-          - { py: pypy2, toxenv: pypy2-epolls, ignore-error: true }
-          - { py: pypy3, toxenv: pypy3-epolls, ignore-error: true }
+          - { py: 2.7, toxenv: py27-epolls, ignore-error: false, os: ubuntu-latest }
+          - { py: 2.7, toxenv: py27-poll, ignore-error: false, os: ubuntu-latest }
+          - { py: 2.7, toxenv: py27-selects, ignore-error: false, os: ubuntu-latest }
+          - { py: 2.7, toxenv: py27-dnspython1, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.5, toxenv: py35-epolls, ignore-error: false, os: ubuntu-20.04 }
+          - { py: 3.5, toxenv: py35-poll, ignore-error: false, os: ubuntu-20.04 }
+          - { py: 3.5, toxenv: py35-selects, ignore-error: false, os: ubuntu-20.04 }
+          - { py: 3.6, toxenv: py36-epolls, ignore-error: false, os: ubuntu-20.04 }
+          - { py: 3.6, toxenv: py36-poll, ignore-error: false, os: ubuntu-20.04 }
+          - { py: 3.6, toxenv: py36-selects, ignore-error: false, os: ubuntu-20.04 }
+          - { py: 3.7, toxenv: py37-epolls, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.7, toxenv: py37-poll, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.7, toxenv: py37-selects, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.8, toxenv: py38-epolls, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.8, toxenv: py38-openssl, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.8, toxenv: py38-poll, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.8, toxenv: py38-selects, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.9, toxenv: py39-epolls, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.9, toxenv: py39-poll, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.9, toxenv: py39-selects, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.9, toxenv: py39-dnspython1, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.x, toxenv: ipv6, ignore-error: false, os: ubuntu-latest }
+          - { py: pypy2.7, toxenv: pypy2-epolls, ignore-error: true, os: ubuntu-20.04 }
+          - { py: pypy3.9, toxenv: pypy3-epolls, ignore-error: true, os: ubuntu-20.04 }
 
     steps:
       - name: install system packages
         run: sudo apt install -y --no-install-recommends ccache libffi-dev default-libmysqlclient-dev libpq-dev libssl-dev libzmq3-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.toxenv }}-${{ hashFiles('.github/workflows/test.yaml', 'setup.py') }}
@@ -68,7 +68,7 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
       - name: cache tox
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ matrix.toxenv }}-${{ hashFiles('tox.ini') }}
@@ -77,7 +77,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: setup python ${{ matrix.py }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py }}
       - name: install codecov, tox

--- a/eventlet/convenience.py
+++ b/eventlet/convenience.py
@@ -157,6 +157,7 @@ def wrap_ssl(sock, *a, **kw):
     """
     return wrap_ssl_impl(sock, *a, **kw)
 
+
 try:
     from eventlet.green import ssl
     wrap_ssl_impl = ssl.wrap_socket

--- a/eventlet/db_pool.py
+++ b/eventlet/db_pool.py
@@ -361,6 +361,8 @@ class GenericConnectionWrapper(object):
         'use_result',
         'warning_count',
     )
+
+
 for _proxy_fun in GenericConnectionWrapper._proxy_funcs:
     # excess wrapper for early binding (closure by value)
     def _wrapper(_proxy_fun=_proxy_fun):

--- a/eventlet/event.py
+++ b/eventlet/event.py
@@ -10,6 +10,7 @@ class NOT_USED:
     def __repr__(self):
         return 'NOT_USED'
 
+
 NOT_USED = NOT_USED()
 
 

--- a/eventlet/green/MySQLdb.py
+++ b/eventlet/green/MySQLdb.py
@@ -16,12 +16,15 @@ __orig_connections = __import__('MySQLdb.connections').connections
 def Connection(*args, **kw):
     conn = tpool.execute(__orig_connections.Connection, *args, **kw)
     return tpool.Proxy(conn, autowrap_names=('cursor',))
+
+
 connect = Connect = Connection
 
 
 # replicate the MySQLdb.connections module but with a tpooled Connection factory
 class MySQLdbConnectionsModule(object):
     pass
+
 
 connections = MySQLdbConnectionsModule()
 for var in dir(__orig_connections):

--- a/eventlet/green/OpenSSL/SSL.py
+++ b/eventlet/green/OpenSSL/SSL.py
@@ -119,6 +119,7 @@ class GreenConnection(greenio.GreenSocket):
                            timeout=self.gettimeout(),
                            timeout_exc=socket.timeout)
 
+
 Connection = ConnectionType = GreenConnection
 
 del greenio

--- a/eventlet/green/Queue.py
+++ b/eventlet/green/Queue.py
@@ -28,5 +28,6 @@ class LifoQueue(queue.LifoQueue):
             maxsize = None
         super(LifoQueue, self).__init__(maxsize)
 
+
 Empty = queue.Empty
 Full = queue.Full

--- a/eventlet/green/os.py
+++ b/eventlet/green/os.py
@@ -29,6 +29,7 @@ def fdopen(fd, *args, **kw):
     except IOError as e:
         raise OSError(*e.args)
 
+
 __original_read__ = os_orig.read
 
 
@@ -50,6 +51,7 @@ def read(fd, n):
             hubs.trampoline(fd, read=True)
         except hubs.IOClosed:
             return ''
+
 
 __original_write__ = os_orig.write
 
@@ -77,6 +79,7 @@ def wait():
     Wait for completion of a child process."""
     return waitpid(0, 0)
 
+
 __original_waitpid__ = os_orig.waitpid
 
 
@@ -94,6 +97,7 @@ def waitpid(pid, options):
             if rpid and status >= 0:
                 return rpid, status
             greenthread.sleep(0.01)
+
 
 __original_open__ = os_orig.open
 

--- a/eventlet/green/threading.py
+++ b/eventlet/green/threading.py
@@ -131,4 +131,5 @@ def current_thread():
 
     return t
 
+
 currentThread = current_thread

--- a/eventlet/green/zmq.py
+++ b/eventlet/green/zmq.py
@@ -148,6 +148,7 @@ def _wraps(source_fn):
         return dest_fn
     return wrapper
 
+
 # Implementation notes: Each socket in 0mq contains a pipe that the
 # background IO threads use to communicate with the socket. These
 # events are important because they tell the socket when it is able to

--- a/eventlet/greenio/py3.py
+++ b/eventlet/greenio/py3.py
@@ -214,4 +214,5 @@ def GreenPipe(name, mode="r", buffering=-1, encoding=None, errors=None,
 
     return _open(name, mode, buffering, encoding, errors, newline, closefd, opener)
 
+
 GreenPipe.__doc__ = greenpipe_doc

--- a/eventlet/greenthread.py
+++ b/eventlet/greenthread.py
@@ -145,6 +145,7 @@ def exc_after(seconds, *throw_args):
     hub = hubs.get_hub()
     return hub.schedule_call_local(seconds, getcurrent().throw, *throw_args)
 
+
 # deprecate, remove
 TimeoutError, with_timeout = (
     support.wrap_deprecated(old, new)(fun) for old, new, fun in (

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -222,6 +222,7 @@ def original(modname):
 
     return sys.modules[original_name]
 
+
 already_patched = {}
 
 

--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -924,6 +924,7 @@ def tcp(q, where, timeout=DNS_QUERY_TIMEOUT, port=53,
 def reset():
     resolver.clear()
 
+
 # Install our coro-friendly replacements for the tcp and udp query methods.
 dns.query.tcp = tcp
 dns.query.udp = udp

--- a/tests/greenpool_test.py
+++ b/tests/greenpool_test.py
@@ -386,6 +386,7 @@ def test_greenpool_type_check():
 class StressException(Exception):
     pass
 
+
 r = random.Random(0)
 
 

--- a/tests/isolated/hub_use_hub_class.py
+++ b/tests/isolated/hub_use_hub_class.py
@@ -5,6 +5,7 @@ __test__ = False
 class Foo(object):
     pass
 
+
 if __name__ == '__main__':
     import eventlet.hubs
     eventlet.hubs.use_hub(Foo)

--- a/tests/isolated/wsgi_connection_timeout.py
+++ b/tests/isolated/wsgi_connection_timeout.py
@@ -188,5 +188,6 @@ def main():
     assert "Traceback" not in output_normal, repr(output_normal)
     print("pass")
 
+
 if __name__ == '__main__':
     main()

--- a/tests/manual/websocket-gunicorn.py
+++ b/tests/manual/websocket-gunicorn.py
@@ -42,6 +42,7 @@ def app(environ, start_response):
     )
     return [body]
 
+
 if __name__ == '__main__':
     cmd = 'gunicorn websocket-gunicorn:app -b 127.0.0.1:5001 -k eventlet -w 1'
     sys.stderr.write('exec ' + cmd + '\n')

--- a/tests/parse_results.py
+++ b/tests/parse_results.py
@@ -31,6 +31,7 @@ def parse_stdout(s):
         hub += '/%s' % reactor
     return testname, hub
 
+
 unittest_delim = '----------------------------------------------------------------------'
 
 
@@ -101,6 +102,7 @@ def main(db):
                       'values (?, ?, ?, ?, ?, ?, ?)',
                       (id, testname, hub, runs, errors, fails, timeouts))
             c.commit()
+
 
 if __name__ == '__main__':
     if not sys.argv[1:]:

--- a/tests/pools_test.py
+++ b/tests/pools_test.py
@@ -248,5 +248,6 @@ SOMETIMES = RuntimeError('I fail half the time')
 class TestTookTooLong(Exception):
     pass
 
+
 if __name__ == '__main__':
     main()

--- a/tests/stdlib/all.py
+++ b/tests/stdlib/all.py
@@ -45,6 +45,7 @@ def assimilate_patched(name):
         except AttributeError:
             print("No test_main for %s, assuming it tests on import" % name)
 
+
 import all_modules
 
 for m in all_modules.get_modules():

--- a/tests/stdlib/all_monkey.py
+++ b/tests/stdlib/all_monkey.py
@@ -19,6 +19,7 @@ def assimilate_real(name):
         except AttributeError:
             print("No test_main for %s, assuming it tests on import" % name)
 
+
 import all_modules
 
 for m in all_modules.get_modules():

--- a/tests/stdlib/test_asyncore.py
+++ b/tests/stdlib/test_asyncore.py
@@ -40,6 +40,7 @@ def new_closeall_check(self, usedefault):
     for c in l:
         self.assertEqual(c.socket.closed, True)
 
+
 HelperFunctionTests.closeall_check = new_closeall_check
 
 try:

--- a/tests/stdlib/test_socket_ssl.py
+++ b/tests/stdlib/test_socket_ssl.py
@@ -13,6 +13,8 @@ def is_resource_enabled(resource):
         return True
     else:
         return i_r_e(resource)
+
+
 test.test_support.is_resource_enabled = is_resource_enabled
 
 try:

--- a/tests/stdlib/test_ssl.py
+++ b/tests/stdlib/test_ssl.py
@@ -19,6 +19,8 @@ def is_resource_enabled(resource):
         return True
     else:
         return i_r_e(resource)
+
+
 test.test_support.is_resource_enabled = is_resource_enabled
 
 patcher.inject(

--- a/tests/stdlib/test_thread__boundedsem.py
+++ b/tests/stdlib/test_thread__boundedsem.py
@@ -6,6 +6,7 @@ from eventlet.green import thread
 def allocate_lock():
     return semaphore.Semaphore(1, 9999)
 
+
 original_allocate_lock = thread.allocate_lock
 thread.allocate_lock = allocate_lock
 original_LockType = thread.LockType

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -32,6 +32,7 @@ def handle(ws):
     else:
         ws.close()
 
+
 wsapp = WebSocketWSGI(handle)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@ exclude = *.egg*,.env,.git,.hg,.tox,_*,build*,dist*,venv*,mock.py,eventlet/green
 ignore = E261,E402,E731,W503
 max-line-length = 123
 
-[pep8]
+[pycodestyle]
 count = 1
 exclude = *.egg*,.env,.git,.hg,.tox,_*,build*,dist*,venv*,mock.py,eventlet/green/http/*
-ignore = E261,E402,E731,W503
+ignore = E261,E402,E731,E741,W503
 max-line-length = 123
 show-source = 1
 statistics = 1
@@ -35,14 +35,14 @@ commands =
     coverage xml -i
 
 [testenv:pep8]
-basepython = python2.7
+basepython = python3
 setenv =
     {[testenv]setenv}
 deps =
-    pep8==1.7.1
+    pycodestyle==2.1.0
 usedevelop = False
 commands =
-    pep8 benchmarks/ eventlet/ tests/
+    pycodestyle benchmarks/ eventlet/ tests/
 
 [testenv]
 passenv =
@@ -62,7 +62,7 @@ deps =
     py27: subprocess32==3.2.7
     py38-openssl: pyopenssl==20.0.0
     pypy{2,3}: psycopg2cffi-compat==1.1
-    py{27,35,36,37}: psycopg2-binary==2.7.4
+    py{27,35,36,37}: psycopg2-binary==2.7.7
     py{35,36,37,38,39}: mysqlclient==2.0.3
     py{38,39}: psycopg2-binary==2.8.4
     setuptools==38.5.1
@@ -70,5 +70,6 @@ deps =
     dnspython1: dnspython<2
 usedevelop = True
 commands =
+    pip install -e .
     nosetests --verbose {env:tox_cover_args} {posargs:tests/}
     coverage xml -i


### PR DESCRIPTION
Not entirely fixed CI.

- github actions ubuntu-latest switched to 22.04 with python3>=3.7
- tool: pep8 was renamed and upgraded to pycodestyle 2.1, fixed 2 empty lines after class/def
- psycopg2-binary 2.7.7 for py3.7
- common github actions upgrade to v3 https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/