### PR TITLE
wsgi: Allow keepalive option to be a timeout

### DIFF
--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -1232,6 +1232,16 @@ class TestHttpd(_TestBase):
         result = read_http(sock)
         self.assertEqual(result.headers_lower['connection'], 'close')
 
+    def test_026b_http_10_zero_keepalive(self):
+        # verify that if an http/1.0 client sends connection: keep-alive
+        # and the server doesn't accept keep-alives, we close the connection
+        self.spawn_server(keepalive=0)
+        sock = eventlet.connect(self.server_addr)
+
+        sock.sendall(b'GET / HTTP/1.0\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n')
+        result = read_http(sock)
+        self.assertEqual(result.headers_lower['connection'], 'close')
+
     def test_027_keepalive_chunked(self):
         self.site.application = chunked_post
         sock = eventlet.connect(self.server_addr)
@@ -1714,6 +1724,47 @@ class TestHttpd(_TestBase):
             assert False, 'Expected ConnectionClosed exception'
         except ConnectionClosed:
             pass
+
+    def test_server_keepalive_as_timeout(self):
+        calls = []
+
+        def call_tracker(env, start_response):
+            calls.append((env['REQUEST_METHOD'], env['PATH_INFO']))
+            start_response('202 Accepted', [])
+            return []
+        self.site.application = call_tracker
+
+        self.spawn_server(socket_timeout=1.0, keepalive=0.1)
+        sock = eventlet.connect(self.server_addr)
+        sock.send(b'GET / HTTP/1.1\r\n')
+        eventlet.sleep(0.1)  # still within socket_timeout
+        sock.send(b'Host: localhost\r\n\r\n')
+        result = read_http(sock)
+        assert 'keep-alive' not in result.headers_lower
+        # now the socket's gone idle, though
+        eventlet.sleep(0.1)
+        try:
+            sock.send(b'PUT / HTTP/1.1\r\nHost: localhost\r\n\r\n')
+            read_http(sock)
+            assert False, 'Expected ConnectionClosed exception'
+        except ConnectionClosed:
+            pass
+        assert calls == [('GET', '/')]  # no PUT!
+
+    def test_server_keepalive_sent_in_headers(self):
+        self.spawn_server(keepalive=2.5)
+        sock = eventlet.connect(self.server_addr)
+        sock.send(
+            b'GET / HTTP/1.1\r\n'
+            b'Connection: keep-alive\r\n'
+            b'Host: localhost\r\n'
+            b'\r\n')
+        result = read_http(sock)
+        assert 'connection' in result.headers_lower
+        assert result.headers_lower['connection'] == 'keep-alive'
+        assert 'keep-alive' in result.headers_lower
+        assert result.headers_lower['keep-alive'] == 'timeout=2'
+        sock.close()
 
     def test_header_name_capitalization(self):
         def wsgi_app(environ, start_response):


### PR DESCRIPTION
Sometimes the server pool fills up; all `max_size` greenthreads are already in use with other connections. One more connection gets `accept()`ed, but then has to wait for a slot to open up to actually be handled.

This works out fine if your clients tend to make a single request then close the connection upon receiving a response. It works out OK-ish when clients are continually pipelining requests; the new connection still has to wait, but at least there's plenty of work getting processed -- it's defensible. It can work out pretty terribly if clients tend to hold on to connections "just in case" -- we're ignoring fresh work from a new client just so we can be ready-to-go if an existing connection wakes up.

There are a couple existing tunings we can use, but they can each have downsides:

- Increasing `max_size` is nice for dealing with idle connections, but can cause hub contention and high latency variance when all those connections are actually busy.
- `socket_timeout` can be used to limit the idle socket time, but it *also* impacts `send`/`recv` operations while processing a request, which may not be desirable.
- `keepalive` can be set to `False`, disabling request pipelining entirely.

Change the `keepalive_timeout` option to `eventlet.wsgi.server` so it can be the timeout to use while waiting for a new request, separate from `socket_timeout`. By default, `socket_timeout` continues to be used.