### PR TITLE
Replace distutils with packaging

### DIFF
--- a/eventlet/support/greenlets.py
+++ b/eventlet/support/greenlets.py
@@ -1,8 +1,8 @@
-import distutils.version
+import packaging.version
 
 import greenlet
 getcurrent = greenlet.greenlet.getcurrent
 GreenletExit = greenlet.greenlet.GreenletExit
-preserves_excinfo = (distutils.version.LooseVersion(greenlet.__version__)
-                     >= distutils.version.LooseVersion('0.3.2'))
+preserves_excinfo = (packaging.version.parse(greenlet.__version__)
+                     >= packaging.version.parse('0.3.2'))
 greenlet = greenlet.greenlet

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
         'greenlet >= 0.3',
         'monotonic >= 1.4;python_version<"3.5"',
         'six >= 1.10.0',
+        'packaging >= 17.0',
     ),
     zip_safe=False,
     long_description=open(


### PR DESCRIPTION
distutils is deprecated.

    DeprecationWarning: distutils Version classes are deprecated. Use
    packaging.version instead.
      >= distutils.version.LooseVersion('0.3.2'))

Do as the warning suggests and use packaging.version instead.
