### PR TITLE
Fix memory leak in module greendns (alternative to #682)

### DIFF
--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -92,11 +92,9 @@ EAI_NONAME_ERROR = socket.gaierror(socket.EAI_NONAME, 'Name or service not known
 # socket.EAI_NODATA is not defined on FreeBSD, probably on some other platforms too.
 # https://lists.freebsd.org/pipermail/freebsd-ports/2003-October/005757.html
 EAI_NODATA_ERROR = EAI_NONAME_ERROR
-EAI_ERRNOS = (socket.EAI_AGAIN, socket.EAI_NONAME)
 if (os.environ.get('EVENTLET_DEPRECATED_EAI_NODATA', '').lower() in ('1', 'y', 'yes')
         and hasattr(socket, 'EAI_NODATA')):
     EAI_NODATA_ERROR = socket.gaierror(socket.EAI_NODATA, 'No address associated with hostname')
-    EAI_ERRNOS = (socket.EAI_AGAIN, socket.EAI_NONAME, socket.EAI_NODATA)
 
 
 def _raise_new_error(error_instance):
@@ -520,7 +518,7 @@ def _getaddrinfo_lookup(host, family, flags):
                 try:
                     answer = resolve(host, qfamily, False, use_network=use_network)
                 except socket.gaierror as e:
-                    if e.errno not in EAI_ERRNOS:
+                    if e.errno not in (socket.EAI_AGAIN, EAI_NONAME_ERROR.errno, EAI_NODATA_ERROR.errno):
                         raise
                     err = e
                 else:

--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -99,7 +99,7 @@ if (os.environ.get('EVENTLET_DEPRECATED_EAI_NODATA', '').lower() in ('1', 'y', '
     EAI_ERRNOS = (socket.EAI_AGAIN, socket.EAI_NONAME, socket.EAI_NODATA)
 
 
-def raise_new_error(error_instance):
+def _raise_new_error(error_instance):
     raise error_instance.__class__(*error_instance.args)
 
 
@@ -471,9 +471,9 @@ def resolve(name, family=socket.AF_INET, raises=True, _proxy=None,
                                    rdtype, dns.rdataclass.IN, None, False)
             raise
     except dns.exception.Timeout:
-        raise_new_error(EAI_EAGAIN_ERROR)
+        _raise_new_error(EAI_EAGAIN_ERROR)
     except dns.exception.DNSException:
-        raise_new_error(EAI_NODATA_ERROR)
+        _raise_new_error(EAI_NODATA_ERROR)
 
 
 def resolve_cname(host):
@@ -483,9 +483,9 @@ def resolve_cname(host):
     except dns.resolver.NoAnswer:
         return host
     except dns.exception.Timeout:
-        raise_new_error(EAI_EAGAIN_ERROR)
+        _raise_new_error(EAI_EAGAIN_ERROR)
     except dns.exception.DNSException:
-        raise_new_error(EAI_NODATA_ERROR)
+        _raise_new_error(EAI_NODATA_ERROR)
     else:
         return str(ans[0].target)
 
@@ -500,9 +500,9 @@ def getaliases(host):
     try:
         return resolver.getaliases(host)
     except dns.exception.Timeout:
-        raise_new_error(EAI_EAGAIN_ERROR)
+        _raise_new_error(EAI_EAGAIN_ERROR)
     except dns.exception.DNSException:
-        raise_new_error(EAI_NODATA_ERROR)
+        _raise_new_error(EAI_NODATA_ERROR)
 
 
 def _getaddrinfo_lookup(host, family, flags):
@@ -511,7 +511,7 @@ def _getaddrinfo_lookup(host, family, flags):
     Helper function for getaddrinfo.
     """
     if flags & socket.AI_NUMERICHOST:
-        raise_new_error(EAI_NONAME_ERROR)
+        _raise_new_error(EAI_NONAME_ERROR)
     addrs = []
     if family == socket.AF_UNSPEC:
         err = None
@@ -622,11 +622,11 @@ def getnameinfo(sockaddr, flags):
             raise TypeError('getnameinfo() argument 1 must be a tuple')
         else:
             # must be ipv6 sockaddr, pretending we don't know how to resolve it
-            raise_new_error(EAI_NONAME_ERROR)
+            _raise_new_error(EAI_NONAME_ERROR)
 
     if (flags & socket.NI_NAMEREQD) and (flags & socket.NI_NUMERICHOST):
         # Conflicting flags.  Punt.
-        raise_new_error(EAI_NONAME_ERROR)
+        _raise_new_error(EAI_NONAME_ERROR)
 
     if is_ipv4_addr(host):
         try:
@@ -637,10 +637,10 @@ def getnameinfo(sockaddr, flags):
             host = rrset[0].target.to_text(omit_final_dot=True)
         except dns.exception.Timeout:
             if flags & socket.NI_NAMEREQD:
-                raise_new_error(EAI_EAGAIN_ERROR)
+                _raise_new_error(EAI_EAGAIN_ERROR)
         except dns.exception.DNSException:
             if flags & socket.NI_NAMEREQD:
-                raise_new_error(EAI_NONAME_ERROR)
+                _raise_new_error(EAI_NONAME_ERROR)
     else:
         try:
             rrset = resolver.query(host)
@@ -649,7 +649,7 @@ def getnameinfo(sockaddr, flags):
             if flags & socket.NI_NUMERICHOST:
                 host = rrset[0].address
         except dns.exception.Timeout:
-            raise_new_error(EAI_EAGAIN_ERROR)
+            _raise_new_error(EAI_EAGAIN_ERROR)
         except dns.exception.DNSException:
             raise socket.gaierror(
                 (socket.EAI_NODATA, 'No address associated with hostname'))

--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -85,15 +85,18 @@ socket = _socket_nodns
 DNS_QUERY_TIMEOUT = 10.0
 HOSTS_TTL = 10.0
 
-EAI_EAGAIN_ERROR = socket.gaierror(socket.EAI_AGAIN, 'Lookup timed out')
-EAI_NONAME_ERROR = socket.gaierror(socket.EAI_NONAME, 'Name or service not known')
+# Exceptions should be initialized when being called, otherwise it will cause a memory leak.
+EAI_EAGAIN_ERROR = lambda : socket.gaierror(socket.EAI_AGAIN, 'Lookup timed out')
+EAI_NONAME_ERROR = lambda : socket.gaierror(socket.EAI_NONAME, 'Name or service not known')
 # EAI_NODATA was removed from RFC3493, it's now replaced with EAI_NONAME
 # socket.EAI_NODATA is not defined on FreeBSD, probably on some other platforms too.
 # https://lists.freebsd.org/pipermail/freebsd-ports/2003-October/005757.html
 EAI_NODATA_ERROR = EAI_NONAME_ERROR
+EAI_ERRNOS = (socket.EAI_AGAIN, socket.EAI_NONAME)
 if (os.environ.get('EVENTLET_DEPRECATED_EAI_NODATA', '').lower() in ('1', 'y', 'yes')
         and hasattr(socket, 'EAI_NODATA')):
-    EAI_NODATA_ERROR = socket.gaierror(socket.EAI_NODATA, 'No address associated with hostname')
+    EAI_NODATA_ERROR = lambda : socket.gaierror(socket.EAI_NODATA, 'No address associated with hostname')
+    EAI_ERRNOS = (socket.EAI_AGAIN, socket.EAI_NONAME, socket.EAI_NODATA)
 
 
 def is_ipv4_addr(host):
@@ -464,9 +467,9 @@ def resolve(name, family=socket.AF_INET, raises=True, _proxy=None,
                                    rdtype, dns.rdataclass.IN, None, False)
             raise
     except dns.exception.Timeout:
-        raise EAI_EAGAIN_ERROR
+        raise EAI_EAGAIN_ERROR()
     except dns.exception.DNSException:
-        raise EAI_NODATA_ERROR
+        raise EAI_NODATA_ERROR()
 
 
 def resolve_cname(host):
@@ -476,9 +479,9 @@ def resolve_cname(host):
     except dns.resolver.NoAnswer:
         return host
     except dns.exception.Timeout:
-        raise EAI_EAGAIN_ERROR
+        raise EAI_EAGAIN_ERROR()
     except dns.exception.DNSException:
-        raise EAI_NODATA_ERROR
+        raise EAI_NODATA_ERROR()
     else:
         return str(ans[0].target)
 
@@ -493,9 +496,9 @@ def getaliases(host):
     try:
         return resolver.getaliases(host)
     except dns.exception.Timeout:
-        raise EAI_EAGAIN_ERROR
+        raise EAI_EAGAIN_ERROR()
     except dns.exception.DNSException:
-        raise EAI_NODATA_ERROR
+        raise EAI_NODATA_ERROR()
 
 
 def _getaddrinfo_lookup(host, family, flags):
@@ -504,7 +507,7 @@ def _getaddrinfo_lookup(host, family, flags):
     Helper function for getaddrinfo.
     """
     if flags & socket.AI_NUMERICHOST:
-        raise EAI_NONAME_ERROR
+        raise EAI_NONAME_ERROR()
     addrs = []
     if family == socket.AF_UNSPEC:
         err = None
@@ -513,7 +516,7 @@ def _getaddrinfo_lookup(host, family, flags):
                 try:
                     answer = resolve(host, qfamily, False, use_network=use_network)
                 except socket.gaierror as e:
-                    if e.errno not in (socket.EAI_AGAIN, EAI_NONAME_ERROR.errno, EAI_NODATA_ERROR.errno):
+                    if e.errno not in EAI_ERRNOS:
                         raise
                     err = e
                 else:
@@ -615,11 +618,11 @@ def getnameinfo(sockaddr, flags):
             raise TypeError('getnameinfo() argument 1 must be a tuple')
         else:
             # must be ipv6 sockaddr, pretending we don't know how to resolve it
-            raise EAI_NONAME_ERROR
+            raise EAI_NONAME_ERROR()
 
     if (flags & socket.NI_NAMEREQD) and (flags & socket.NI_NUMERICHOST):
         # Conflicting flags.  Punt.
-        raise EAI_NONAME_ERROR
+        raise EAI_NONAME_ERROR()
 
     if is_ipv4_addr(host):
         try:
@@ -630,10 +633,10 @@ def getnameinfo(sockaddr, flags):
             host = rrset[0].target.to_text(omit_final_dot=True)
         except dns.exception.Timeout:
             if flags & socket.NI_NAMEREQD:
-                raise EAI_EAGAIN_ERROR
+                raise EAI_EAGAIN_ERROR()
         except dns.exception.DNSException:
             if flags & socket.NI_NAMEREQD:
-                raise EAI_NONAME_ERROR
+                raise EAI_NONAME_ERROR()
     else:
         try:
             rrset = resolver.query(host)
@@ -642,7 +645,7 @@ def getnameinfo(sockaddr, flags):
             if flags & socket.NI_NUMERICHOST:
                 host = rrset[0].address
         except dns.exception.Timeout:
-            raise EAI_EAGAIN_ERROR
+            raise EAI_EAGAIN_ERROR()
         except dns.exception.DNSException:
             raise socket.gaierror(
                 (socket.EAI_NODATA, 'No address associated with hostname'))

--- a/tests/greendns_test.py
+++ b/tests/greendns_test.py
@@ -940,9 +940,12 @@ class TestRaiseErrors(tests.LimitedTestCase):
 
         # Raise exception multiple times
         for _ in range(3):
-            with greendns._raise_new_error(greendns.EAI_EAGAIN_ERROR) as error:
-                self.assertIsNone(error.__traceback__)
-                self.assertIsNone(greendns.EAI_EAGAIN_ERROR.__traceback__)
+            with self.assertRaises(socket.gaierror) as error:
+                greendns._raise_new_error(greendns.EAI_EAGAIN_ERROR)
+
+            self.assertIsNone(error.exception.__traceback__)
+        # Check no memory leak of exception instance
+        self.assertIsNone(greendns.EAI_EAGAIN_ERROR.__traceback__)
 
 
 def test_reverse_name():

--- a/tests/greendns_test.py
+++ b/tests/greendns_test.py
@@ -935,9 +935,6 @@ class TestRaiseErrors(tests.LimitedTestCase):
 
     def test_raise_new_error(self):
         # https://github.com/eventlet/eventlet/issues/810
-        if not hasattr(greendns.EAI_EAGAIN_ERROR, "__traceback__"):
-            self.skipTest("Python version does not implement PEP-3134, skip this testcase.")
-
         # Raise exception multiple times
         for _ in range(3):
             with self.assertRaises(socket.gaierror) as error:

--- a/tests/greendns_test.py
+++ b/tests/greendns_test.py
@@ -931,6 +931,20 @@ class TinyDNSTests(tests.LimitedTestCase):
             self.assertEqual(list(response.rrset.items)[0].address, expected_ip)
 
 
+class TestRaiseErrors(tests.LimitedTestCase):
+
+    def test_raise_new_error(self):
+        # https://github.com/eventlet/eventlet/issues/810
+        if not hasattr(greendns.EAI_EAGAIN_ERROR, "__traceback__"):
+            self.skipTest("Python version does not implement PEP-3134, skip this testcase.")
+
+        # Raise exception multiple times
+        for _ in range(3):
+            with greendns._raise_new_error(greendns.EAI_EAGAIN_ERROR) as error:
+                self.assertIsNone(error.__traceback__)
+                self.assertIsNone(greendns.EAI_EAGAIN_ERROR.__traceback__)
+
+
 def test_reverse_name():
     tests.run_isolated('greendns_from_address_203.py')
 


### PR DESCRIPTION
Change `EAI_*_ERROR` to `lambda` expression, and initialize them
 when being called, to avoid memory leak with `__traceback__.tb_next`

fixes https://github.com/eventlet/eventlet/issues/810