### PR TITLE
Add entry points to allow to run examples simply by installing eventlet

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -19,6 +19,8 @@ WSGI Server
 
 .. literalinclude:: ../examples/wsgi.py
 
+This example can be launched by using the command ``$ eventlet_wsgi_example``
+
 .. _echo_server_example:
 
 Echo Server
@@ -27,6 +29,8 @@ Echo Server
 
 .. literalinclude:: ../examples/echoserver.py
 
+This example can be launched by using the command ``$ eventlet_echoserver_example``
+
 .. _socket_connect_example:
 
 Socket Connect
@@ -34,6 +38,8 @@ Socket Connect
 ``examples/connect.py``
 
 .. literalinclude:: ../examples/connect.py
+
+This example can be launched by using the command ``$ eventlet_connect_example``
 
 .. _chat_server_example:
 
@@ -45,6 +51,8 @@ This is a little different from the echo server, in that it broadcasts the
 messages to all participants, not just the sender.
         
 .. literalinclude:: ../examples/chat_server.py
+
+This example can be launched by using the command ``$ eventlet_chat_server_example``
 
 .. _feed_scraper_example:
 

--- a/examples/chat_bridge.py
+++ b/examples/chat_bridge.py
@@ -1,5 +1,8 @@
 import sys
-from zmq import FORWARDER, PUB, SUB, SUBSCRIBE
+try:
+    from zmq import FORWARDER, PUB, SUB, SUBSCRIBE
+except ImportError:
+    raise RuntimeError("zmq is required, please install it first")
 from zmq.devices import Device
 
 

--- a/examples/distributed_websocket_chat.py
+++ b/examples/distributed_websocket_chat.py
@@ -20,7 +20,10 @@ from collections import defaultdict
 from eventlet import spawn_n, sleep
 from eventlet import wsgi
 from eventlet import websocket
-from eventlet.green import zmq
+try:
+    from eventlet.green import zmq
+except ImportError:
+    raise RuntimeError("zmq is required, please install it first")
 from eventlet.hubs import get_hub, use_hub
 from uuid import uuid1
 

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,15 @@ setuptools.setup(
         "Programming Language :: Python",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
-    ]
+    ],
+    entry_points={
+        'console_scripts': [
+            'eventlet_chat_bridge_example = examples.chat_bridge:__main__',
+            'eventlet_chat_server_example = examples.chat_server:__main__',
+            'eventlet_connect_example = examples.connect:__main__',
+            'eventlet_distributed_websocket_chat_example = examples.distributed_websocket_chat:__main__',
+            'eventlet_echoserver_example = examples.echoserver:__main__',
+            'eventlet_wsgi_example = examples.wsgi:__main__',
+        ]
+    }
 )


### PR DESCRIPTION
These entry points allow to run some of the examples described in the documentation directly from the command line.

Eventlet users doesn't have to copy these examples to run them.

All entry points are suffixed with "example" to highlight their nature.

They can help to save time to run tests and checks locally.