### PR TITLE
Green CI, part 2: pass tests on 3.10 and 3.11

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,7 @@ jobs:
           - { py: "3.10", toxenv: py310-poll, ignore-error: false, os: ubuntu-latest }
           - { py: "3.10", toxenv: py310-selects, ignore-error: false, os: ubuntu-latest }
           - { py: "3.10", toxenv: ipv6, ignore-error: false, os: ubuntu-latest }
+          - { py: "3.11", toxenv: py311-epolls, ignore-error: false, os: ubuntu-latest }
           - { py: pypy3.9, toxenv: pypy3-epolls, ignore-error: true, os: ubuntu-20.04 }
 
     steps:

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -429,8 +429,13 @@ def _fix_py3_rlock(old, tid):
     import threading
     from eventlet.green.thread import allocate_lock
     new = threading._PyRLock()
-    assert hasattr(new, "_block")
-    assert hasattr(new, "_owner")
+    if not hasattr(new, "_block") or not hasattr(new, "_owner"):
+        # These will only fail if Python changes its internal implementation of
+        # _PyRLock:
+        raise RuntimeError(
+            "INTERNAL BUG. Perhaps you are using a major version " +
+            "of Python that is unsupported by eventlet? Please file a bug " +
+            "at https://github.com/eventlet/eventlet/issues/new")
     new._block = allocate_lock()
     acquired = False
     while old._is_owned():


### PR DESCRIPTION
Fixes #830 

I came up with a simpler fix for 3.10/3.11 support that continues to use the same RLock code in Python stdlib.