### PR TITLE
Stop claiming to create universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [metadata]
 description_file = README.rst
-
-[wheel]
-universal = True


### PR DESCRIPTION
From https://wheel.readthedocs.io/en/stable/user_guide.html :

> If your project contains no C extensions and is expected to work on both Python 2 and 3, you will want to tell wheel to produce universal wheels by adding this to your `setup.cfg` file:
>
>     [bdist_wheel]
>     universal = 1

Now that we [no longer support Python 2](https://github.com/eventlet/eventlet/pull/827), it's inappropriate for us to claim that our wheels are universal. Note that claiming that a wheel is universal when it's not has caused trouble for other projects in the past; see https://github.com/PyCQA/bandit/issues/663