### PR TITLE
Fix Python 3.13 compat by adding missing attibute '_is_main_interpreter'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ Unreleased
 ==========
 
 * Dropped support for Python 3.7 and earlier.
+* Fix Python 3.13 compat by adding missing attibute '_is_main_interpreter' https://github.com/eventlet/eventlet/pull/847
 
 0.33.3
 ======

--- a/eventlet/green/thread.py
+++ b/eventlet/green/thread.py
@@ -15,6 +15,8 @@ error = __thread.error
 LockType = Lock
 __threadcount = 0
 
+if hasattr(__thread, "_is_main_interpreter"):
+    _is_main_interpreter = __thread._is_main_interpreter
 
 if six.PY3:
     def _set_sentinel():


### PR DESCRIPTION
https://github.com/python/cpython/issues/112826

Python 3.13 doesn't have workaround and so eventlet is broken with Python versions higher than 3.12.

Fix #838
Fix #604