### PR TITLE
Drop old code based on python < 3.7, part 1: eventlet directory

### DIFF
--- a/eventlet/__init__.py
+++ b/eventlet/__init__.py
@@ -2,11 +2,6 @@ import os
 import sys
 import warnings
 
-if sys.version_info < (3, 5):
-    warnings.warn(
-        "Support for your Python version is deprecated and will be removed in the future",
-        DeprecationWarning,
-    )
 
 from eventlet import convenience
 from eventlet import event

--- a/eventlet/backdoor.py
+++ b/eventlet/backdoor.py
@@ -1,4 +1,3 @@
-
 from code import InteractiveConsole
 import errno
 import socket

--- a/eventlet/backdoor.py
+++ b/eventlet/backdoor.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 from code import InteractiveConsole
 import errno

--- a/eventlet/backdoor.py
+++ b/eventlet/backdoor.py
@@ -34,7 +34,7 @@ class FileProxy:
         try:
             self.f.write(data, *a, **kw)
             self.f.flush()
-        except socket.error as e:
+        except OSError as e:
             if get_errno(e) != errno.EPIPE:
                 raise
 
@@ -107,7 +107,7 @@ def backdoor_server(sock, locals=None):
             try:
                 socketpair = sock.accept()
                 backdoor(socketpair, locals)
-            except socket.error as e:
+            except OSError as e:
                 # Broken pipe means it was shutdown
                 if get_errno(e) != errno.EPIPE:
                     raise

--- a/eventlet/backdoor.py
+++ b/eventlet/backdoor.py
@@ -21,7 +21,7 @@ except AttributeError:
     sys.ps2 = '... '
 
 
-class FileProxy(object):
+class FileProxy:
     def __init__(self, f):
         self.f = f
 

--- a/eventlet/convenience.py
+++ b/eventlet/convenience.py
@@ -63,7 +63,7 @@ def listen(addr, family=socket.AF_INET, backlog=50, reuse_addr=True, reuse_port=
         try:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         # OSError is enough on Python 3+
-        except (OSError, socket.error) as ex:
+        except OSError as ex:
             if support.get_errno(ex) in (22, 92):
                 # A famous platform defines unsupported socket option.
                 # https://github.com/eventlet/eventlet/issues/380

--- a/eventlet/corolocal.py
+++ b/eventlet/corolocal.py
@@ -12,7 +12,7 @@ def get_ident():
 
 # the entire purpose of this class is to store off the constructor
 # arguments in a local variable without calling __init__ directly
-class _localbase(object):
+class _localbase:
     __slots__ = '_local__args', '_local__greens'
 
     def __new__(cls, *args, **kw):

--- a/eventlet/coros.py
+++ b/eventlet/coros.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 from eventlet import event as _event
 

--- a/eventlet/coros.py
+++ b/eventlet/coros.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from eventlet import event as _event
 
 
-class metaphore(object):
+class metaphore:
     """This is sort of an inverse semaphore: a counter that starts at 0 and
     waits only if nonzero. It's used to implement a "wait for all" scenario.
 

--- a/eventlet/coros.py
+++ b/eventlet/coros.py
@@ -1,4 +1,3 @@
-
 from eventlet import event as _event
 
 

--- a/eventlet/dagpool.py
+++ b/eventlet/dagpool.py
@@ -41,7 +41,7 @@ class PropagateError(Exception):
         # initialize base class with a reasonable string message
         msg = "PropagateError({0}): {1}: {2}" \
               .format(key, exc.__class__.__name__, exc)
-        super(PropagateError, self).__init__(msg)
+        super().__init__(msg)
         self.msg = msg
         # Unless we set args, this is unpickleable:
         # https://bugs.python.org/issue1692335

--- a/eventlet/dagpool.py
+++ b/eventlet/dagpool.py
@@ -39,7 +39,7 @@ class PropagateError(Exception):
     """
     def __init__(self, key, exc):
         # initialize base class with a reasonable string message
-        msg = "PropagateError({0}): {1}: {2}" \
+        msg = "PropagateError({}): {}: {}" \
               .format(key, exc.__class__.__name__, exc)
         super().__init__(msg)
         self.msg = msg

--- a/eventlet/dagpool.py
+++ b/eventlet/dagpool.py
@@ -123,7 +123,7 @@ class DAGPool:
         try:
             # If a dict is passed, copy it. Don't risk a subsequent
             # modification to passed dict affecting our internal state.
-            iteritems = six.iteritems(preload)
+            iteritems = preload.items()
         except AttributeError:
             # Not a dict, just an iterable of (key, value) pairs
             iteritems = preload
@@ -258,7 +258,7 @@ class DAGPool:
             return set(keys)
         else:
             # keys arg omitted -- use all the keys we know about
-            return set(six.iterkeys(self.coros)) | set(six.iterkeys(self.values))
+            return set(self.coros.keys()) | set(self.values.keys())
 
     def _wait_each(self, pending):
         """
@@ -394,7 +394,7 @@ class DAGPool:
         """
         # Iterate over 'depends' items, relying on self.spawn() not to
         # context-switch so no one can modify 'depends' along the way.
-        for key, deps in six.iteritems(depends):
+        for key, deps in depends.items():
             self.spawn(key, deps, function, *args, **kwds)
 
     def kill(self, key):
@@ -502,7 +502,7 @@ class DAGPool:
         """
         # Explicitly return a copy rather than an iterator: don't assume our
         # caller will finish iterating before new values are posted.
-        return tuple(six.iterkeys(self.values))
+        return tuple(self.values.keys())
 
     def items(self):
         """
@@ -511,7 +511,7 @@ class DAGPool:
         # Don't assume our caller will finish iterating before new values are
         # posted.
         return tuple((key, self._value_or_raise(value))
-                     for key, value in six.iteritems(self.values))
+                     for key, value in self.values.items())
 
     def running(self):
         """
@@ -529,7 +529,7 @@ class DAGPool:
         """
         # return snapshot; don't assume caller will finish iterating before we
         # next modify self.coros
-        return tuple(six.iterkeys(self.coros))
+        return tuple(self.coros.keys())
 
     def waiting(self):
         """
@@ -567,7 +567,7 @@ class DAGPool:
         # some or all of those keys, because those greenthreads have not yet
         # regained control since values were posted. So make a point of
         # excluding values that are now available.
-        available = set(six.iterkeys(self.values))
+        available = set(self.values.keys())
 
         if key is not _MISSING:
             # waiting_for(key) is semantically different than waiting_for().
@@ -596,7 +596,7 @@ class DAGPool:
         # are now available. Filter out any pair in which 'pending' is empty,
         # that is, that greenthread will be unblocked next time it resumes.
         # Make a dict from those pairs.
-        return dict((key, pending)
-                    for key, pending in ((key, (coro.pending - available))
-                                         for key, coro in six.iteritems(self.coros))
-                    if pending)
+        return {key: pending
+                for key, pending in ((key, (coro.pending - available))
+                                     for key, coro in self.coros.items())
+                if pending}

--- a/eventlet/dagpool.py
+++ b/eventlet/dagpool.py
@@ -53,7 +53,7 @@ class PropagateError(Exception):
         return self.msg
 
 
-class DAGPool(object):
+class DAGPool:
     """
     A DAGPool is a pool that constrains greenthreads, not by max concurrency,
     but by data dependencies.

--- a/eventlet/dagpool.py
+++ b/eventlet/dagpool.py
@@ -5,7 +5,6 @@
 
 from eventlet.event import Event
 from eventlet import greenthread
-import six
 import collections
 
 

--- a/eventlet/db_pool.py
+++ b/eventlet/db_pool.py
@@ -308,7 +308,7 @@ class RawConnectionPool(BaseConnectionPool):
 ConnectionPool = TpooledConnectionPool
 
 
-class GenericConnectionWrapper(object):
+class GenericConnectionWrapper:
     def __init__(self, baseconn):
         self._base = baseconn
 
@@ -416,7 +416,7 @@ class PooledConnectionWrapper(GenericConnectionWrapper):
         # self.close()
 
 
-class DatabaseConnector(object):
+class DatabaseConnector:
     """
     This is an object which will maintain a collection of database
     connection pools on a per-host basis.

--- a/eventlet/db_pool.py
+++ b/eventlet/db_pool.py
@@ -59,9 +59,7 @@ class BaseConnectionPool(Pool):
         self.connect_timeout = connect_timeout
         self._expiration_timer = None
         self.cleanup = cleanup
-        super(BaseConnectionPool, self).__init__(min_size=min_size,
-                                                 max_size=max_size,
-                                                 order_as_stack=True)
+        super().__init__(min_size=min_size, max_size=max_size, order_as_stack=True)
 
     def _schedule_expiration(self):
         """Sets up a timer that will call _expire_old_connections when the
@@ -173,7 +171,7 @@ class BaseConnectionPool(Pool):
                 print("Connection.close raised: %s" % (sys.exc_info()[1]))
 
     def get(self):
-        conn = super(BaseConnectionPool, self).get()
+        conn = super().get()
 
         # None is a flag value that means that put got called with
         # something it couldn't use
@@ -229,12 +227,12 @@ class BaseConnectionPool(Pool):
                 raise
 
         if conn is not None:
-            super(BaseConnectionPool, self).put((now, created_at, conn))
+            super().put((now, created_at, conn))
         else:
             # wake up any waiters with a flag value that indicates
             # they need to manufacture a connection
             if self.waiting() > 0:
-                super(BaseConnectionPool, self).put(None)
+                super().put(None)
             else:
                 # no waiters -- just change the size
                 self.current_size -= 1
@@ -386,7 +384,7 @@ class PooledConnectionWrapper(GenericConnectionWrapper):
     """
 
     def __init__(self, baseconn, pool):
-        super(PooledConnectionWrapper, self).__init__(baseconn)
+        super().__init__(baseconn)
         self._pool = pool
 
     def __nonzero__(self):

--- a/eventlet/db_pool.py
+++ b/eventlet/db_pool.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 from collections import deque
 from contextlib import contextmanager

--- a/eventlet/db_pool.py
+++ b/eventlet/db_pool.py
@@ -1,4 +1,3 @@
-
 from collections import deque
 from contextlib import contextmanager
 import sys

--- a/eventlet/debug.py
+++ b/eventlet/debug.py
@@ -36,7 +36,7 @@ class Spew:
                 try:
                     src = inspect.getsourcelines(frame)
                     line = src[lineno]
-                except IOError:
+                except OSError:
                     line = 'Unknown code named [%s].  VM instruction #%d' % (
                         frame.f_code.co_name, frame.f_lasti)
             if self.trace_names is None or name in self.trace_names:

--- a/eventlet/debug.py
+++ b/eventlet/debug.py
@@ -12,7 +12,7 @@ __all__ = ['spew', 'unspew', 'format_hub_listeners', 'format_hub_timers',
            'hub_prevent_multiple_readers', 'hub_timer_stacks',
            'hub_blocking_detection']
 
-_token_splitter = re.compile('\W+')
+_token_splitter = re.compile(r'\W+')
 
 
 class Spew:

--- a/eventlet/debug.py
+++ b/eventlet/debug.py
@@ -1,6 +1,5 @@
 """The debug module contains utilities and functions for better
 debugging Eventlet-powered applications."""
-from __future__ import print_function
 
 import os
 import sys

--- a/eventlet/debug.py
+++ b/eventlet/debug.py
@@ -16,7 +16,7 @@ __all__ = ['spew', 'unspew', 'format_hub_listeners', 'format_hub_timers',
 _token_splitter = re.compile('\W+')
 
 
-class Spew(object):
+class Spew:
 
     def __init__(self, trace_names=None, show_values=True):
         self.trace_names = trace_names

--- a/eventlet/event.py
+++ b/eventlet/event.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 from eventlet import hubs
 from eventlet.support import greenlets as greenlet

--- a/eventlet/event.py
+++ b/eventlet/event.py
@@ -1,4 +1,3 @@
-
 from eventlet import hubs
 from eventlet.support import greenlets as greenlet
 

--- a/eventlet/event.py
+++ b/eventlet/event.py
@@ -14,7 +14,7 @@ class NOT_USED:
 NOT_USED = NOT_USED()
 
 
-class Event(object):
+class Event:
     """An abstraction where an arbitrary number of coroutines
     can wait for one event from another.
 

--- a/eventlet/green/BaseHTTPServer.py
+++ b/eventlet/green/BaseHTTPServer.py
@@ -1,10 +1,9 @@
 from eventlet import patcher
 from eventlet.green import socket
 from eventlet.green import SocketServer
-import six
 
 patcher.inject(
-    'BaseHTTPServer' if six.PY2 else 'http.server',
+    'http.server',
     globals(),
     ('socket', socket),
     ('SocketServer', SocketServer),

--- a/eventlet/green/MySQLdb.py
+++ b/eventlet/green/MySQLdb.py
@@ -22,7 +22,7 @@ connect = Connect = Connection
 
 
 # replicate the MySQLdb.connections module but with a tpooled Connection factory
-class MySQLdbConnectionsModule(object):
+class MySQLdbConnectionsModule:
     pass
 
 

--- a/eventlet/green/Queue.py
+++ b/eventlet/green/Queue.py
@@ -12,21 +12,21 @@ class Queue(queue.Queue):
     def __init__(self, maxsize=0):
         if maxsize == 0:
             maxsize = None
-        super(Queue, self).__init__(maxsize)
+        super().__init__(maxsize)
 
 
 class PriorityQueue(queue.PriorityQueue):
     def __init__(self, maxsize=0):
         if maxsize == 0:
             maxsize = None
-        super(PriorityQueue, self).__init__(maxsize)
+        super().__init__(maxsize)
 
 
 class LifoQueue(queue.LifoQueue):
     def __init__(self, maxsize=0):
         if maxsize == 0:
             maxsize = None
-        super(LifoQueue, self).__init__(maxsize)
+        super().__init__(maxsize)
 
 
 Empty = queue.Empty

--- a/eventlet/green/SocketServer.py
+++ b/eventlet/green/SocketServer.py
@@ -3,10 +3,9 @@ from eventlet import patcher
 from eventlet.green import socket
 from eventlet.green import select
 from eventlet.green import threading
-import six
 
 patcher.inject(
-    'SocketServer' if six.PY2 else 'socketserver',
+    'socketserver',
     globals(),
     ('socket', socket),
     ('select', select),

--- a/eventlet/green/builtin.py
+++ b/eventlet/green/builtin.py
@@ -13,7 +13,6 @@ from eventlet import hubs
 from eventlet.hubs import hub
 from eventlet.patcher import slurp_properties
 import sys
-import six
 
 __all__ = dir(builtins_orig)
 __patched__ = ['open']

--- a/eventlet/green/builtin.py
+++ b/eventlet/green/builtin.py
@@ -17,22 +17,10 @@ import six
 
 __all__ = dir(builtins_orig)
 __patched__ = ['open']
-if six.PY2:
-    __patched__ += ['file']
-
 slurp_properties(builtins_orig, globals(),
                  ignore=__patched__, srckeys=dir(builtins_orig))
 
 hubs.get_hub()
-
-if six.PY2:
-    __original_file = file
-
-    class file(__original_file):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            hubs.notify_opened(self.fileno())
-
 
 __original_open = open
 __opening = False

--- a/eventlet/green/builtin.py
+++ b/eventlet/green/builtin.py
@@ -30,7 +30,7 @@ if six.PY2:
 
     class file(__original_file):
         def __init__(self, *args, **kwargs):
-            super(file, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
             hubs.notify_opened(self.fileno())
 
 

--- a/eventlet/green/http/__init__.py
+++ b/eventlet/green/http/__init__.py
@@ -52,8 +52,6 @@
 # 8. By copying, installing or otherwise using Python, Licensee
 # agrees to be bound by the terms and conditions of this License
 # Agreement.
-import six
-assert six.PY3, 'This is a Python 3 module'
 
 from enum import IntEnum
 

--- a/eventlet/green/http/client.py
+++ b/eventlet/green/http/client.py
@@ -1477,7 +1477,7 @@ else:
                      timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
                      source_address=None, *, context=None,
                      check_hostname=None):
-            super(HTTPSConnection, self).__init__(host, port, timeout,
+            super().__init__(host, port, timeout,
                                                   source_address)
             self.key_file = key_file
             self.cert_file = cert_file

--- a/eventlet/green/http/client.py
+++ b/eventlet/green/http/client.py
@@ -126,10 +126,7 @@ import email.parser
 import email.message
 import io
 import re
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 from urllib.parse import urlsplit
 
 from eventlet.green import http, os, socket

--- a/eventlet/green/http/client.py
+++ b/eventlet/green/http/client.py
@@ -1126,7 +1126,7 @@ class HTTPConnection:
 
                 if encode_chunked and self._http_vsn == 11:
                     # chunked encoding
-                    chunk = '{0:X}\r\n'.format(len(chunk)).encode('ascii') + chunk + b'\r\n'
+                    chunk = '{:X}\r\n'.format(len(chunk)).encode('ascii') + chunk + b'\r\n'
                 self.send(chunk)
 
             if encode_chunked and self._http_vsn == 11:
@@ -1294,7 +1294,7 @@ class HTTPConnection:
         encode_chunked = kwds.pop('encode_chunked', False)
         if kwds:
             # mimic interpreter error for unrecognized keyword
-            raise TypeError("endheaders() got an unexpected keyword argument '{0}'"
+            raise TypeError("endheaders() got an unexpected keyword argument '{}'"
                             .format(kwds.popitem()[0]))
 
         if self.__state == _CS_REQ_STARTED:
@@ -1308,7 +1308,7 @@ class HTTPConnection:
         encode_chunked = kwds.pop('encode_chunked', False)
         if kwds:
             # mimic interpreter error for unrecognized keyword
-            raise TypeError("request() got an unexpected keyword argument '{0}'"
+            raise TypeError("request() got an unexpected keyword argument '{}'"
                             .format(kwds.popitem()[0]))
         self._send_request(method, url, body, headers, encode_chunked)
 

--- a/eventlet/green/http/cookiejar.py
+++ b/eventlet/green/http/cookiejar.py
@@ -254,7 +254,7 @@ def _str2time(day, mon, yr, hr, min, sec, tz):
 
 STRICT_DATE_RE = re.compile(
     r"^[SMTWF][a-z][a-z], (\d\d) ([JFMASOND][a-z][a-z]) "
-    "(\d\d\d\d) (\d\d):(\d\d):(\d\d) GMT$", re.ASCII)
+    r"(\d\d\d\d) (\d\d):(\d\d):(\d\d) GMT$", re.ASCII)
 WEEKDAY_RE = re.compile(
     r"^(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)[a-z]*,?\s*", re.I | re.ASCII)
 LOOSE_HTTP_DATE_RE = re.compile(
@@ -331,7 +331,7 @@ def http2time(text):
     return _str2time(day, mon, yr, hr, min, sec, tz)
 
 ISO_DATE_RE = re.compile(
-    """^
+    r"""^
     (\d{4})              # year
        [-\/]?
     (\d\d?)              # numerical month
@@ -465,7 +465,7 @@ def split_header_words(header_values):
                 pairs = []
             else:
                 # skip junk
-                non_junk, nr_junk_chars = re.subn("^[=\s;]*", "", text)
+                non_junk, nr_junk_chars = re.subn(r"^[=\s;]*", "", text)
                 assert nr_junk_chars > 0, (
                     "split_header_words bug: '%s', '%s', %s" %
                     (orig_text, text, pairs))

--- a/eventlet/green/http/cookies.py
+++ b/eventlet/green/http/cookies.py
@@ -511,7 +511,7 @@ class Morsel(dict):
 #
 
 _LegalKeyChars  = r"\w\d!#%&'~_`><@,:/\$\*\+\-\.\^\|\)\(\?\}\{\="
-_LegalValueChars = _LegalKeyChars + '\[\]'
+_LegalValueChars = _LegalKeyChars + r'\[\]'
 _CookiePattern = re.compile(r"""
     (?x)                           # This is a verbose pattern
     \s*                            # Optional whitespace at start of cookie

--- a/eventlet/green/httplib.py
+++ b/eventlet/green/httplib.py
@@ -10,13 +10,10 @@ try:
 except ImportError:
     pass
 
-if six.PY2:
-    patcher.inject('httplib', globals(), *to_patch)
-if six.PY3:
-    from eventlet.green.http import client
-    for name in dir(client):
-        if name not in patcher.__exclude:
-            globals()[name] = getattr(client, name)
+from eventlet.green.http import client
+for name in dir(client):
+    if name not in patcher.__exclude:
+        globals()[name] = getattr(client, name)
 
 if __name__ == '__main__':
     test()

--- a/eventlet/green/httplib.py
+++ b/eventlet/green/httplib.py
@@ -1,6 +1,5 @@
 from eventlet import patcher
 from eventlet.green import socket
-import six
 
 to_patch = [('socket', socket)]
 

--- a/eventlet/green/os.py
+++ b/eventlet/green/os.py
@@ -43,7 +43,7 @@ def read(fd, n):
         except OSError as e:
             if get_errno(e) != errno.EAGAIN:
                 raise
-        except socket.error as e:
+        except OSError as e:
             if get_errno(e) == errno.EPIPE:
                 return ''
             raise
@@ -67,7 +67,7 @@ def write(fd, st):
         except OSError as e:
             if get_errno(e) != errno.EAGAIN:
                 raise
-        except socket.error as e:
+        except OSError as e:
             if get_errno(e) != errno.EPIPE:
                 raise
         hubs.trampoline(fd, write=True)

--- a/eventlet/green/os.py
+++ b/eventlet/green/os.py
@@ -26,7 +26,7 @@ def fdopen(fd, *args, **kw):
         raise TypeError('fd should be int, not %r' % fd)
     try:
         return greenio.GreenPipe(fd, *args, **kw)
-    except IOError as e:
+    except OSError as e:
         raise OSError(*e.args)
 
 
@@ -40,7 +40,7 @@ def read(fd, n):
     while True:
         try:
             return __original_read__(fd, n)
-        except (OSError, IOError) as e:
+        except OSError as e:
             if get_errno(e) != errno.EAGAIN:
                 raise
         except socket.error as e:
@@ -64,7 +64,7 @@ def write(fd, st):
     while True:
         try:
             return __original_write__(fd, st)
-        except (OSError, IOError) as e:
+        except OSError as e:
             if get_errno(e) != errno.EAGAIN:
                 raise
         except socket.error as e:

--- a/eventlet/green/profile.py
+++ b/eventlet/green/profile.py
@@ -40,9 +40,9 @@ import functools
 
 from eventlet import greenthread
 from eventlet import patcher
-import six
+import _thread
 
-thread = patcher.original(six.moves._thread.__name__)  # non-monkeypatched module needed
+thread = patcher.original(_thread.__name__)  # non-monkeypatched module needed
 
 
 # This class provides the start() and stop() functions

--- a/eventlet/green/profile.py
+++ b/eventlet/green/profile.py
@@ -144,10 +144,10 @@ class Profile(profile_orig.Profile):
         # we must keep the timings dicts separate for each tasklet, since it contains
         # the 'ns' item, recursion count of each function in that tasklet.  This is
         # used in the Unwind dude.
-        for tasklet, (cur, timings) in six.iteritems(oldtimings):
+        for tasklet, (cur, timings) in oldtimings.items():
             self.Unwind(cur, timings)
 
-            for k, v in six.iteritems(timings):
+            for k, v in timings.items():
                 if k not in self.timings:
                     self.timings[k] = v
                 else:
@@ -157,7 +157,7 @@ class Profile(profile_orig.Profile):
                     cc += v[0]
                     tt += v[2]
                     ct += v[3]
-                    for k1, v1 in six.iteritems(v[4]):
+                    for k1, v1 in v[4].items():
                         callers[k1] = callers.get(k1, 0) + v1
                     self.timings[k] = cc, ns, tt, ct, callers
 
@@ -213,7 +213,7 @@ Profile.dispatch = dict(profile_orig.Profile.dispatch, **{
     'c_return': Profile.trace_dispatch_c_return_extend_back,
 })
 # Add automatic tasklet detection to the callbacks.
-Profile.dispatch = dict((k, ContextWrap(v)) for k, v in six.viewitems(Profile.dispatch))
+Profile.dispatch = {k: ContextWrap(v) for k, v in Profile.dispatch.items()}
 
 
 # run statements shamelessly stolen from profile.py

--- a/eventlet/green/select.py
+++ b/eventlet/green/select.py
@@ -1,6 +1,5 @@
 import eventlet
 from eventlet.hubs import get_hub
-import six
 __select = eventlet.patcher.original('select')
 error = __select.error
 

--- a/eventlet/green/select.py
+++ b/eventlet/green/select.py
@@ -17,12 +17,12 @@ def get_fileno(obj):
     try:
         f = obj.fileno
     except AttributeError:
-        if not isinstance(obj, six.integer_types):
+        if not isinstance(obj, int):
             raise TypeError("Expected int or long, got %s" % type(obj))
         return obj
     else:
         rv = f()
-        if not isinstance(rv, six.integer_types):
+        if not isinstance(rv, int):
             raise TypeError("Expected int or long, got %s" % type(rv))
         return rv
 
@@ -71,7 +71,7 @@ def select(read_list, write_list, error_list, timeout=None):
     if timeout is not None:
         timers.append(hub.schedule_call_global(timeout, on_timeout))
     try:
-        for k, v in six.iteritems(ds):
+        for k, v in ds.items():
             if v.get('read'):
                 listeners.append(hub.add(hub.READ, k, on_read, current.throw, lambda: None))
             if v.get('write'):

--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -59,7 +59,7 @@ class GreenSSLSocket(_original_sslsocket):
                 ssl_version=PROTOCOL_SSLv23, ca_certs=None,
                 do_handshake_on_connect=True, *args, **kw):
         if sys.version_info < (3, 7):
-            return super(GreenSSLSocket, cls).__new__(cls)
+            return super().__new__(cls)
         else:
             if not isinstance(sock, GreenSocket):
                 sock = GreenSocket(sock)
@@ -133,7 +133,7 @@ class GreenSSLSocket(_original_sslsocket):
         if sys.version_info < (3, 7):
             # nonblocking socket handshaking on connect got disabled so let's pretend it's disabled
             # even when it's on
-            super(GreenSSLSocket, self).__init__(
+            super().__init__(
                 sock.fd, keyfile, certfile, server_side, cert_reqs, ssl_version,
                 ca_certs, do_handshake_on_connect and six.PY2, *args, **kw)
         # the superclass initializer trashes the methods so we remove
@@ -203,14 +203,14 @@ class GreenSSLSocket(_original_sslsocket):
         """Write DATA to the underlying SSL channel.  Returns
         number of bytes of DATA actually transmitted."""
         return self._call_trampolining(
-            super(GreenSSLSocket, self).write, data)
+            super().write, data)
 
     def read(self, len=1024, buffer=None):
         """Read up to LEN bytes and return them.
         Return zero-length string on EOF."""
         try:
             return self._call_trampolining(
-                super(GreenSSLSocket, self).read, len, buffer)
+                super().read, len, buffer)
         except IOClosed:
             if buffer is None:
                 return b''
@@ -220,7 +220,7 @@ class GreenSSLSocket(_original_sslsocket):
     def send(self, data, flags=0):
         if self._sslobj:
             return self._call_trampolining(
-                super(GreenSSLSocket, self).send, data, flags)
+                super().send, data, flags)
         else:
             trampoline(self, write=True, timeout_exc=timeout_exc('timed out'))
             return socket.send(self, data, flags)
@@ -323,22 +323,22 @@ class GreenSSLSocket(_original_sslsocket):
         if not self.act_non_blocking:
             trampoline(self, read=True, timeout=self.gettimeout(),
                        timeout_exc=timeout_exc('timed out'))
-        return super(GreenSSLSocket, self).recvfrom(addr, buflen, flags)
+        return super().recvfrom(addr, buflen, flags)
 
     def recvfrom_into(self, buffer, nbytes=None, flags=0):
         if not self.act_non_blocking:
             trampoline(self, read=True, timeout=self.gettimeout(),
                        timeout_exc=timeout_exc('timed out'))
-        return super(GreenSSLSocket, self).recvfrom_into(buffer, nbytes, flags)
+        return super().recvfrom_into(buffer, nbytes, flags)
 
     def unwrap(self):
         return GreenSocket(self._call_trampolining(
-            super(GreenSSLSocket, self).unwrap))
+            super().unwrap))
 
     def do_handshake(self):
         """Perform a TLS/SSL handshake."""
         return self._call_trampolining(
-            super(GreenSSLSocket, self).do_handshake)
+            super().do_handshake)
 
     def _socket_connect(self, addr):
         real_connect = socket.connect

--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -23,7 +23,6 @@ __patched__ = [
 
 _original_sslsocket = __ssl.SSLSocket
 _original_sslcontext = __ssl.SSLContext
-_is_under_py_3_7 = sys.version_info < (3, 7)
 _is_py_3_7 = sys.version_info[:2] == (3, 7)
 _original_wrap_socket = __ssl.SSLContext.wrap_socket
 
@@ -59,7 +58,7 @@ class GreenSSLSocket(_original_sslsocket):
                 server_side=False, cert_reqs=CERT_NONE,
                 ssl_version=PROTOCOL_SSLv23, ca_certs=None,
                 do_handshake_on_connect=True, *args, **kw):
-        if _is_under_py_3_7:
+        if sys.version_info < (3, 7):
             return super(GreenSSLSocket, cls).__new__(cls)
         else:
             if not isinstance(sock, GreenSocket):
@@ -131,7 +130,7 @@ class GreenSSLSocket(_original_sslsocket):
             # this assignment
             self._timeout = sock.gettimeout()
 
-        if _is_under_py_3_7:
+        if sys.version_info < (3, 7):
             # nonblocking socket handshaking on connect got disabled so let's pretend it's disabled
             # even when it's on
             super(GreenSSLSocket, self).__init__(
@@ -406,7 +405,7 @@ class GreenSSLSocket(_original_sslsocket):
         except NameError:
             self._sslobj = sslobj
         else:
-            if _is_under_py_3_7:
+            if sys.version_info < (3, 7):
                 self._sslobj = SSLObject(sslobj, owner=self)
             else:
                 self._sslobj = sslobj

--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -10,7 +10,6 @@ from eventlet.greenio import (
 )
 from eventlet.hubs import trampoline, IOClosed
 from eventlet.support import get_errno, PY33
-import six
 from contextlib import contextmanager
 
 orig_socket = __import__('socket')
@@ -125,17 +124,12 @@ class GreenSSLSocket(_original_sslsocket):
             sock = GreenSocket(sock)
         self.act_non_blocking = sock.act_non_blocking
 
-        if six.PY2:
-            # On Python 2 SSLSocket constructor queries the timeout, it'd break without
-            # this assignment
-            self._timeout = sock.gettimeout()
-
         if sys.version_info < (3, 7):
             # nonblocking socket handshaking on connect got disabled so let's pretend it's disabled
             # even when it's on
             super().__init__(
                 sock.fd, keyfile, certfile, server_side, cert_reqs, ssl_version,
-                ca_certs, do_handshake_on_connect and six.PY2, *args, **kw)
+                ca_certs, False, *args, **kw)
         # the superclass initializer trashes the methods so we remove
         # the local-object versions of them and let the actual class
         # methods shine through

--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -146,18 +146,17 @@ class GreenSSLSocket(_original_sslsocket):
         except AttributeError:
             pass
 
-        if six.PY3:
-            # Python 3 SSLSocket construction process overwrites the timeout so restore it
-            self._timeout = sock.gettimeout()
+        # Python 3 SSLSocket construction process overwrites the timeout so restore it
+        self._timeout = sock.gettimeout()
 
-            # it also sets timeout to None internally apparently (tested with 3.4.2)
-            _original_sslsocket.settimeout(self, 0.0)
-            assert _original_sslsocket.gettimeout(self) == 0.0
+        # it also sets timeout to None internally apparently (tested with 3.4.2)
+        _original_sslsocket.settimeout(self, 0.0)
+        assert _original_sslsocket.gettimeout(self) == 0.0
 
-            # see note above about handshaking
-            self.do_handshake_on_connect = do_handshake_on_connect
-            if do_handshake_on_connect and self._connected:
-                self.do_handshake()
+        # see note above about handshaking
+        self.do_handshake_on_connect = do_handshake_on_connect
+        if do_handshake_on_connect and self._connected:
+            self.do_handshake()
 
     def settimeout(self, timeout):
         self._timeout = timeout
@@ -389,11 +388,8 @@ class GreenSSLSocket(_original_sslsocket):
             sslwrap = _ssl.sslwrap
         except AttributeError:
             # sslwrap was removed in 3.x and later in 2.7.9
-            if six.PY2:
-                sslobj = self._context._wrap_socket(self._sock, server_side, ssl_sock=self)
-            else:
-                context = self.context if PY33 else self._context
-                sslobj = context._wrap_socket(self, server_side, server_hostname=self.server_hostname)
+            context = self.context if PY33 else self._context
+            sslobj = context._wrap_socket(self, server_side, server_hostname=self.server_hostname)
         else:
             sslobj = sslwrap(self._sock, server_side, self.keyfile, self.certfile,
                              self.cert_reqs, self.ssl_version,

--- a/eventlet/green/subprocess.py
+++ b/eventlet/green/subprocess.py
@@ -11,9 +11,8 @@ from eventlet.green import select, threading, time
 __patched__ = ['call', 'check_call', 'Popen']
 to_patch = [('select', select), ('threading', threading), ('time', time)]
 
-if sys.version_info > (3, 4):
-    from eventlet.green import selectors
-    to_patch.append(('selectors', selectors))
+from eventlet.green import selectors
+to_patch.append(('selectors', selectors))
 
 patcher.inject('subprocess', globals(), *to_patch)
 subprocess_orig = patcher.original("subprocess")

--- a/eventlet/green/subprocess.py
+++ b/eventlet/green/subprocess.py
@@ -6,7 +6,6 @@ import eventlet
 from eventlet import greenio
 from eventlet import patcher
 from eventlet.green import select, threading, time
-import six
 
 
 __patched__ = ['call', 'check_call', 'Popen']

--- a/eventlet/green/subprocess.py
+++ b/eventlet/green/subprocess.py
@@ -103,17 +103,14 @@ class Popen(subprocess_orig.Popen):
         # just want a version that uses eventlet.green.select.select()
         # instead of select.select().
         _communicate = FunctionType(
-            six.get_function_code(six.get_unbound_function(
-                subprocess_orig.Popen._communicate)),
+            subprocess_orig.Popen._communicate.__code__,
             globals())
         try:
             _communicate_with_select = FunctionType(
-                six.get_function_code(six.get_unbound_function(
-                    subprocess_orig.Popen._communicate_with_select)),
+                subprocess_orig.Popen._communicate_with_select.__code__,
                 globals())
             _communicate_with_poll = FunctionType(
-                six.get_function_code(six.get_unbound_function(
-                    subprocess_orig.Popen._communicate_with_poll)),
+                subprocess_orig.Popen._communicate_with_poll.__code__,
                 globals())
         except AttributeError:
             pass
@@ -122,9 +119,8 @@ class Popen(subprocess_orig.Popen):
 # Borrow subprocess.call() and check_call(), but patch them so they reference
 # OUR Popen class rather than subprocess.Popen.
 def patched_function(function):
-    new_function = FunctionType(six.get_function_code(function), globals())
-    if six.PY3:
-        new_function.__kwdefaults__ = function.__kwdefaults__
+    new_function = FunctionType(function.__code__, globals())
+    new_function.__kwdefaults__ = function.__kwdefaults__
     new_function.__defaults__ = function.__defaults__
     return new_function
 

--- a/eventlet/green/thread.py
+++ b/eventlet/green/thread.py
@@ -1,5 +1,5 @@
 """Implements the standard thread module, using greenthreads."""
-from six.moves import _thread as __thread
+import _thread as __thread
 import six
 from eventlet.support import greenlets as greenlet
 from eventlet import greenthread
@@ -18,13 +18,14 @@ __threadcount = 0
 if hasattr(__thread, "_is_main_interpreter"):
     _is_main_interpreter = __thread._is_main_interpreter
 
-if six.PY3:
-    def _set_sentinel():
-        # TODO this is a dummy code, reimplementing this may be needed:
-        # https://hg.python.org/cpython/file/b5e9bc4352e1/Modules/_threadmodule.c#l1203
-        return allocate_lock()
 
-    TIMEOUT_MAX = __thread.TIMEOUT_MAX
+def _set_sentinel():
+    # TODO this is a dummy code, reimplementing this may be needed:
+    # https://hg.python.org/cpython/file/b5e9bc4352e1/Modules/_threadmodule.c#l1203
+    return allocate_lock()
+
+
+TIMEOUT_MAX = __thread.TIMEOUT_MAX
 
 
 def _count():

--- a/eventlet/green/thread.py
+++ b/eventlet/green/thread.py
@@ -1,6 +1,5 @@
 """Implements the standard thread module, using greenthreads."""
 import _thread as __thread
-import six
 from eventlet.support import greenlets as greenlet
 from eventlet import greenthread
 from eventlet.lock import Lock

--- a/eventlet/green/threading.py
+++ b/eventlet/green/threading.py
@@ -9,10 +9,7 @@ __patched__ = ['_start_new_thread', '_allocate_lock',
                '_sleep', 'local', 'stack_size', 'Lock', 'currentThread',
                'current_thread', '_after_fork', '_shutdown']
 
-if six.PY2:
-    __patched__ += ['_get_ident']
-else:
-    __patched__ += ['get_ident', '_set_sentinel']
+__patched__ += ['get_ident', '_set_sentinel']
 
 __orig_threading = eventlet.patcher.original('threading')
 __threadlocal = __orig_threading.local()

--- a/eventlet/green/threading.py
+++ b/eventlet/green/threading.py
@@ -3,7 +3,6 @@ import eventlet
 from eventlet.green import thread
 from eventlet.green import time
 from eventlet.support import greenlets as greenlet
-import six
 
 __patched__ = ['_start_new_thread', '_allocate_lock',
                '_sleep', 'local', 'stack_size', 'Lock', 'currentThread',
@@ -19,7 +18,7 @@ __patched_enumerate = None
 eventlet.patcher.inject(
     'threading',
     globals(),
-    ('thread' if six.PY2 else '_thread', thread),
+    ('_thread', thread),
     ('time', time))
 
 

--- a/eventlet/green/threading.py
+++ b/eventlet/green/threading.py
@@ -29,7 +29,7 @@ eventlet.patcher.inject(
 _count = 1
 
 
-class _GreenThread(object):
+class _GreenThread:
     """Wrapper for GreenThread objects to provide Thread-like attributes
     and methods"""
 

--- a/eventlet/green/urllib/__init__.py
+++ b/eventlet/green/urllib/__init__.py
@@ -5,36 +5,3 @@ from eventlet.green import httplib
 from eventlet.green import ftplib
 import six
 
-if six.PY2:
-    to_patch = [('socket', socket), ('httplib', httplib),
-                ('time', time), ('ftplib', ftplib)]
-    try:
-        from eventlet.green import ssl
-        to_patch.append(('ssl', ssl))
-    except ImportError:
-        pass
-
-    patcher.inject('urllib', globals(), *to_patch)
-    try:
-        URLopener
-    except NameError:
-        patcher.inject('urllib.request', globals(), *to_patch)
-
-
-    # patch a bunch of things that have imports inside the
-    # function body; this is lame and hacky but I don't feel
-    # too bad because urllib is a hacky pile of junk that no
-    # one should be using anyhow
-    URLopener.open_http = patcher.patch_function(URLopener.open_http, ('httplib', httplib))
-    if hasattr(URLopener, 'open_https'):
-        URLopener.open_https = patcher.patch_function(URLopener.open_https, ('httplib', httplib))
-
-    URLopener.open_ftp = patcher.patch_function(URLopener.open_ftp, ('ftplib', ftplib))
-    ftpwrapper.init = patcher.patch_function(ftpwrapper.init, ('ftplib', ftplib))
-    ftpwrapper.retrfile = patcher.patch_function(ftpwrapper.retrfile, ('ftplib', ftplib))
-
-    del patcher
-
-    # Run test program when run as a script
-    if __name__ == '__main__':
-        main()

--- a/eventlet/green/urllib/__init__.py
+++ b/eventlet/green/urllib/__init__.py
@@ -3,5 +3,3 @@ from eventlet.green import socket
 from eventlet.green import time
 from eventlet.green import httplib
 from eventlet.green import ftplib
-import six
-

--- a/eventlet/green/zmq.py
+++ b/eventlet/green/zmq.py
@@ -221,7 +221,7 @@ class Socket(_Socket):
     """
 
     def __init__(self, context, socket_type):
-        super(Socket, self).__init__(context, socket_type)
+        super().__init__(context, socket_type)
 
         self.__dict__['_eventlet_send_event'] = _BlockedThread()
         self.__dict__['_eventlet_recv_event'] = _BlockedThread()
@@ -250,7 +250,7 @@ class Socket(_Socket):
 
     @_wraps(_Socket.close)
     def close(self, linger=None):
-        super(Socket, self).close(linger)
+        super().close(linger)
         if self._eventlet_listener is not None:
             eventlet.hubs.get_hub().remove(self._eventlet_listener)
             self.__dict__['_eventlet_listener'] = None

--- a/eventlet/green/zmq.py
+++ b/eventlet/green/zmq.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """The :mod:`zmq` module wraps the :class:`Socket` and :class:`Context`
 found in :mod:`pyzmq <zmq>` to be non blocking.
 """

--- a/eventlet/green/zmq.py
+++ b/eventlet/green/zmq.py
@@ -26,7 +26,7 @@ class LockReleaseError(Exception):
     pass
 
 
-class _QueueLock(object):
+class _QueueLock:
     """A Lock that can be acquired by at most one thread. Any other
     thread calling acquire will be blocked in a queue. When release
     is called, the threads are awoken in the order they blocked,
@@ -76,7 +76,7 @@ class _QueueLock(object):
                 self._hub.schedule_call_global(0, self._waiters[0].switch)
 
 
-class _BlockedThread(object):
+class _BlockedThread:
     """Is either empty, or represents a single blocked thread that
     blocked itself by calling the block() method. The thread can be
     awoken by calling wake(). Wake() can be called multiple times and

--- a/eventlet/greenio/__init__.py
+++ b/eventlet/greenio/__init__.py
@@ -1,5 +1,3 @@
-import six
-
 from eventlet.greenio.base import *  # noqa
 
 from eventlet.greenio.py3 import *  # noqa

--- a/eventlet/greenio/__init__.py
+++ b/eventlet/greenio/__init__.py
@@ -2,7 +2,4 @@ import six
 
 from eventlet.greenio.base import *  # noqa
 
-if six.PY2:
-    from eventlet.greenio.py2 import *  # noqa
-else:
-    from eventlet.greenio.py3 import *  # noqa
+from eventlet.greenio.py3 import *  # noqa

--- a/eventlet/greenio/base.py
+++ b/eventlet/greenio/base.py
@@ -120,7 +120,7 @@ except ImportError:
     _GLOBAL_DEFAULT_TIMEOUT = object()
 
 
-class GreenSocket(object):
+class GreenSocket:
     """
     Green version of socket.socket class, that is intended to be 100%
     API-compatible.
@@ -473,7 +473,7 @@ try:
     from OpenSSL import SSL
 except ImportError:
     # pyOpenSSL not installed, define exceptions anyway for convenience
-    class SSL(object):
+    class SSL:
         class WantWriteError(Exception):
             pass
 

--- a/eventlet/greenio/base.py
+++ b/eventlet/greenio/base.py
@@ -8,7 +8,6 @@ import warnings
 import eventlet
 from eventlet.hubs import trampoline, notify_opened, IOClosed
 from eventlet.support import get_errno
-import six
 
 __all__ = [
     'GreenSocket', '_GLOBAL_DEFAULT_TIMEOUT', 'set_nonblocking',

--- a/eventlet/greenio/py2.py
+++ b/eventlet/greenio/py2.py
@@ -22,10 +22,10 @@ class GreenPipe(_fileobject):
     __doc__ = greenpipe_doc
 
     def __init__(self, f, mode='r', bufsize=-1):
-        if not isinstance(f, six.string_types + (int, file)):
+        if not isinstance(f, (str,) + (int, file)):
             raise TypeError('f(ile) should be int, str, unicode or file, not %r' % f)
 
-        if isinstance(f, six.string_types):
+        if isinstance(f, str):
             f = open(f, mode, 0)
 
         if isinstance(f, int):

--- a/eventlet/greenio/py2.py
+++ b/eventlet/greenio/py2.py
@@ -10,7 +10,6 @@ from eventlet.greenio.base import (
 )
 from eventlet.hubs import trampoline, notify_close, notify_opened, IOClosed
 from eventlet.support import get_errno
-import six
 
 __all__ = ['_fileobject', 'GreenPipe']
 

--- a/eventlet/greenio/py2.py
+++ b/eventlet/greenio/py2.py
@@ -39,7 +39,7 @@ class GreenPipe(_fileobject):
             self._name = f.name
             f.close()
 
-        super(GreenPipe, self).__init__(_SocketDuckForFd(fileno), mode, bufsize)
+        super().__init__(_SocketDuckForFd(fileno), mode, bufsize)
         set_nonblocking(self)
         self.softspace = 0
 
@@ -56,7 +56,7 @@ class GreenPipe(_fileobject):
             (id(self) < 0) and (sys.maxint + id(self)) or id(self))
 
     def close(self):
-        super(GreenPipe, self).close()
+        super().close()
         for method in [
                 'fileno', 'flush', 'isatty', 'next', 'read', 'readinto',
                 'readline', 'readlines', 'seek', 'tell', 'truncate',

--- a/eventlet/greenio/py2.py
+++ b/eventlet/greenio/py2.py
@@ -118,7 +118,7 @@ class GreenPipe(_fileobject):
             raise IOError(*e.args)
 
 
-class _SocketDuckForFd(object):
+class _SocketDuckForFd:
     """Class implementing all socket method used by _fileobject
     in cooperative manner using low level os I/O calls.
     """

--- a/eventlet/greenio/py2.py
+++ b/eventlet/greenio/py2.py
@@ -82,7 +82,7 @@ class GreenPipe(_fileobject):
         try:
             return os.lseek(self.fileno(), 0, 1) - self._get_readahead_len()
         except OSError as e:
-            raise IOError(*e.args)
+            raise OSError(*e.args)
 
     def seek(self, offset, whence=0):
         self.flush()
@@ -93,7 +93,7 @@ class GreenPipe(_fileobject):
         try:
             rv = os.lseek(self.fileno(), offset, whence)
         except OSError as e:
-            raise IOError(*e.args)
+            raise OSError(*e.args)
         else:
             self._clear_readahead_buf()
             return rv
@@ -106,7 +106,7 @@ class GreenPipe(_fileobject):
             try:
                 rv = os.ftruncate(self.fileno(), size)
             except OSError as e:
-                raise IOError(*e.args)
+                raise OSError(*e.args)
             else:
                 self.seek(size)  # move position&clear buffer
                 return rv
@@ -115,7 +115,7 @@ class GreenPipe(_fileobject):
         try:
             return os.isatty(self.fileno())
         except OSError as e:
-            raise IOError(*e.args)
+            raise OSError(*e.args)
 
 
 class _SocketDuckForFd:
@@ -162,7 +162,7 @@ class _SocketDuckForFd:
                 return data
             except OSError as e:
                 if get_errno(e) not in SOCKET_BLOCKING:
-                    raise IOError(*e.args)
+                    raise OSError(*e.args)
             self._trampoline(self, read=True)
 
     def recv_into(self, buf, nbytes=0, flags=0):
@@ -178,7 +178,7 @@ class _SocketDuckForFd:
                 return os.write(self._fileno, data)
             except OSError as e:
                 if get_errno(e) not in SOCKET_BLOCKING:
-                    raise IOError(*e.args)
+                    raise OSError(*e.args)
                 else:
                     trampoline(self, write=True)
 
@@ -190,7 +190,7 @@ class _SocketDuckForFd:
             total_sent = os_write(fileno, data)
         except OSError as e:
             if get_errno(e) != errno.EAGAIN:
-                raise IOError(*e.args)
+                raise OSError(*e.args)
             total_sent = 0
         while total_sent < len_data:
             self._trampoline(self, write=True)
@@ -198,7 +198,7 @@ class _SocketDuckForFd:
                 total_sent += os_write(fileno, data[total_sent:])
             except OSError as e:
                 if get_errno(e) != errno. EAGAIN:
-                    raise IOError(*e.args)
+                    raise OSError(*e.args)
 
     def __del__(self):
         self._close()

--- a/eventlet/greenio/py3.py
+++ b/eventlet/greenio/py3.py
@@ -20,7 +20,6 @@ from eventlet.greenio.base import (
 )
 from eventlet.hubs import notify_close, notify_opened, IOClosed, trampoline
 from eventlet.support import get_errno
-import six
 
 __all__ = ['_fileobject', 'GreenPipe']
 

--- a/eventlet/greenio/py3.py
+++ b/eventlet/greenio/py3.py
@@ -57,7 +57,7 @@ class GreenFileIO(_OriginalIOBase):
         if self._seekable is None:
             try:
                 _original_os.lseek(self._fileno, 0, _original_os.SEEK_CUR)
-            except IOError as e:
+            except OSError as e:
                 if get_errno(e) == errno.ESPIPE:
                     self._seekable = False
                 else:
@@ -85,7 +85,7 @@ class GreenFileIO(_OriginalIOBase):
                 return _original_os.read(self._fileno, size)
             except OSError as e:
                 if get_errno(e) not in SOCKET_BLOCKING:
-                    raise IOError(*e.args)
+                    raise OSError(*e.args)
                 self._trampoline(self, read=True)
 
     def readall(self):
@@ -98,7 +98,7 @@ class GreenFileIO(_OriginalIOBase):
                 buf.append(chunk)
             except OSError as e:
                 if get_errno(e) not in SOCKET_BLOCKING:
-                    raise IOError(*e.args)
+                    raise OSError(*e.args)
                 self._trampoline(self, read=True)
 
     def readinto(self, b):
@@ -112,7 +112,7 @@ class GreenFileIO(_OriginalIOBase):
         try:
             return _original_os.isatty(self.fileno())
         except OSError as e:
-            raise IOError(*e.args)
+            raise OSError(*e.args)
 
     def _trampoline(self, fd, read=False, write=False, timeout=None, timeout_exc=None):
         if self._closed:
@@ -141,7 +141,7 @@ class GreenFileIO(_OriginalIOBase):
                 written = _original_os.write(self._fileno, view[offset:])
             except OSError as e:
                 if get_errno(e) not in SOCKET_BLOCKING:
-                    raise IOError(*e.args)
+                    raise OSError(*e.args)
                 trampoline(self, write=True)
             else:
                 offset += written
@@ -164,7 +164,7 @@ class GreenFileIO(_OriginalIOBase):
         try:
             rv = _original_os.ftruncate(self._fileno, size)
         except OSError as e:
-            raise IOError(*e.args)
+            raise OSError(*e.args)
         else:
             self.seek(size)  # move position&clear buffer
             return rv
@@ -173,7 +173,7 @@ class GreenFileIO(_OriginalIOBase):
         try:
             return _original_os.lseek(self._fileno, offset, whence)
         except OSError as e:
-            raise IOError(*e.args)
+            raise OSError(*e.args)
 
     def __enter__(self):
         return self

--- a/eventlet/greenio/py3.py
+++ b/eventlet/greenio/py3.py
@@ -37,7 +37,7 @@ class GreenFileIO(_OriginalIOBase):
             fileno = name
             self._name = "<fd:%d>" % fileno
         else:
-            assert isinstance(name, six.string_types)
+            assert isinstance(name, str)
             with open(name, mode) as fd:
                 self._name = fd.name
                 fileno = _original_os.dup(fd.fileno())
@@ -196,7 +196,7 @@ if hasattr(_original_pyio, 'text_encoding'):
 
 _pyio_open = getattr(_original_pyio.open, '__wrapped__', _original_pyio.open)
 _open = FunctionType(
-    six.get_function_code(_pyio_open),
+    _pyio_open.__code__,
     _open_environment,
 )
 

--- a/eventlet/greenpool.py
+++ b/eventlet/greenpool.py
@@ -18,10 +18,10 @@ class GreenPool:
         try:
             size = int(size)
         except ValueError as e:
-            msg = 'GreenPool() expect size :: int, actual: {0} {1}'.format(type(size), str(e))
+            msg = 'GreenPool() expect size :: int, actual: {} {}'.format(type(size), str(e))
             raise TypeError(msg)
         if size < 0:
-            msg = 'GreenPool() expect size >= 0, actual: {0}'.format(repr(size))
+            msg = 'GreenPool() expect size >= 0, actual: {}'.format(repr(size))
             raise ValueError(msg)
         self.size = size
         self.coroutines_running = set()

--- a/eventlet/greenpool.py
+++ b/eventlet/greenpool.py
@@ -242,7 +242,7 @@ class GreenPile:
 # instead relying on the spawning process to send one in when it's done
 class GreenMap(GreenPile):
     def __init__(self, size_or_pool):
-        super(GreenMap, self).__init__(size_or_pool)
+        super().__init__(size_or_pool)
         self.waiters = queue.LightQueue(maxsize=self.pool.size)
 
     def done_spawning(self):

--- a/eventlet/greenpool.py
+++ b/eventlet/greenpool.py
@@ -181,7 +181,7 @@ class GreenPool:
            for result in pool.imap(worker, open("filename", 'r')):
                print(result)
         """
-        return self.starmap(function, six.moves.zip(*iterables))
+        return self.starmap(function, zip(*iterables))
 
 
 class GreenPile:

--- a/eventlet/greenpool.py
+++ b/eventlet/greenpool.py
@@ -10,7 +10,7 @@ __all__ = ['GreenPool', 'GreenPile']
 DEBUG = True
 
 
-class GreenPool(object):
+class GreenPool:
     """The GreenPool class is a pool of green threads.
     """
 
@@ -184,7 +184,7 @@ class GreenPool(object):
         return self.starmap(function, six.moves.zip(*iterables))
 
 
-class GreenPile(object):
+class GreenPile:
     """GreenPile is an abstraction representing a bunch of I/O-related tasks.
 
     Construct a GreenPile with an existing GreenPool object.  The GreenPile will

--- a/eventlet/greenpool.py
+++ b/eventlet/greenpool.py
@@ -3,7 +3,6 @@ import traceback
 import eventlet
 from eventlet import queue
 from eventlet.support import greenlets as greenlet
-import six
 
 __all__ = ['GreenPool', 'GreenPile']
 

--- a/eventlet/greenthread.py
+++ b/eventlet/greenthread.py
@@ -7,7 +7,6 @@ from eventlet import support
 from eventlet import timeout
 from eventlet.hubs import timer
 from eventlet.support import greenlets as greenlet
-import six
 import warnings
 
 __all__ = ['getcurrent', 'sleep', 'spawn', 'spawn_n',

--- a/eventlet/greenthread.py
+++ b/eventlet/greenthread.py
@@ -284,7 +284,7 @@ def kill(g, *throw_args):
         # method never got called
         def just_raise(*a, **kw):
             if throw_args:
-                six.reraise(throw_args[0], throw_args[1], throw_args[2])
+                raise throw_args[1].with_traceback(throw_args[2])
             else:
                 raise greenlet.GreenletExit()
         g.run = just_raise

--- a/eventlet/hubs/__init__.py
+++ b/eventlet/hubs/__init__.py
@@ -71,7 +71,7 @@ def use_hub(mod=None):
         del _threadlocal.hub
 
     classname = ''
-    if isinstance(mod, six.string_types):
+    if isinstance(mod, str):
         assert mod.strip(), "Need to specify a hub"
         if '.' in mod or ':' in mod:
             modulename, _, classname = mod.strip().partition(':')

--- a/eventlet/hubs/__init__.py
+++ b/eventlet/hubs/__init__.py
@@ -5,7 +5,6 @@ import warnings
 
 from eventlet import patcher
 from eventlet.support import greenlets as greenlet
-import six
 
 
 __all__ = ["use_hub", "get_hub", "get_default_hub", "trampoline"]

--- a/eventlet/hubs/epolls.py
+++ b/eventlet/hubs/epolls.py
@@ -12,7 +12,7 @@ def is_available():
 # are identical in value to the poll constants
 class Hub(poll.Hub):
     def __init__(self, clock=None):
-        super(Hub, self).__init__(clock=clock)
+        super().__init__(clock=clock)
         self.poll = select.epoll()
 
     def add(self, evtype, fileno, cb, tb, mac):

--- a/eventlet/hubs/epolls.py
+++ b/eventlet/hubs/epolls.py
@@ -22,7 +22,7 @@ class Hub(poll.Hub):
         listener = hub.BaseHub.add(self, evtype, fileno, cb, tb, mac)
         try:
             self.register(fileno, new=not oldlisteners)
-        except IOError as ex:    # ignore EEXIST, #80
+        except OSError as ex:    # ignore EEXIST, #80
             if support.get_errno(ex) != errno.EEXIST:
                 raise
         return listener

--- a/eventlet/hubs/hub.py
+++ b/eventlet/hubs/hub.py
@@ -27,8 +27,6 @@ try:
 except ImportError:
     from time import monotonic
 
-import six
-
 g_prevent_multiple_readers = True
 
 READ = "read"

--- a/eventlet/hubs/hub.py
+++ b/eventlet/hubs/hub.py
@@ -42,7 +42,7 @@ def closed_callback(fileno):
     pass
 
 
-class FdListener(object):
+class FdListener:
 
     def __init__(self, evtype, fileno, cb, tb, mark_as_closed):
         """ The following are required:
@@ -109,7 +109,7 @@ def alarm_handler(signum, frame):
     raise RuntimeError("Blocking detector ALARMED at" + str(inspect.getframeinfo(frame)))
 
 
-class BaseHub(object):
+class BaseHub:
     """ Base hub class for easing the implementation of subclasses that are
     specific to a particular underlying event architecture. """
 

--- a/eventlet/hubs/hub.py
+++ b/eventlet/hubs/hub.py
@@ -90,7 +90,7 @@ class DebugListener(FdListener):
     def __init__(self, evtype, fileno, cb, tb, mark_as_closed):
         self.where_called = traceback.format_stack()
         self.greenlet = greenlet.getcurrent()
-        super(DebugListener, self).__init__(evtype, fileno, cb, tb, mark_as_closed)
+        super().__init__(evtype, fileno, cb, tb, mark_as_closed)
 
     def __repr__(self):
         return "DebugListener(%r, %r, %r, %r, %r, %r)\n%sEndDebugFdListener" % (

--- a/eventlet/hubs/hub.py
+++ b/eventlet/hubs/hub.py
@@ -195,7 +195,7 @@ class BaseHub:
             their greenlets queued up to send.
         """
         found = False
-        for evtype, bucket in six.iteritems(self.secondaries):
+        for evtype, bucket in self.secondaries.items():
             if fileno in bucket:
                 for listener in bucket[fileno]:
                     found = True
@@ -205,7 +205,7 @@ class BaseHub:
 
         # For the primary listeners, we actually need to call remove,
         # which may modify the underlying OS polling objects.
-        for evtype, bucket in six.iteritems(self.listeners):
+        for evtype, bucket in self.listeners.items():
             if fileno in bucket:
                 listener = bucket[fileno]
                 found = True

--- a/eventlet/hubs/kqueue.py
+++ b/eventlet/hubs/kqueue.py
@@ -30,8 +30,8 @@ class Hub(hub.BaseHub):
     def _reinit_kqueue(self):
         self.kqueue.close()
         self._init_kqueue()
-        events = [e for i in six.itervalues(self._events)
-                  for e in six.itervalues(i)]
+        events = [e for i in self._events.values()
+                  for e in i.values()]
         self.kqueue.control(events, 0, 0)
 
     def _control(self, events, max_events, timeout):

--- a/eventlet/hubs/kqueue.py
+++ b/eventlet/hubs/kqueue.py
@@ -37,7 +37,7 @@ class Hub(hub.BaseHub):
     def _control(self, events, max_events, timeout):
         try:
             return self.kqueue.control(events, max_events, timeout)
-        except (OSError, IOError):
+        except OSError:
             # have we forked?
             if os.getpid() != self._pid:
                 self._reinit_kqueue()

--- a/eventlet/hubs/kqueue.py
+++ b/eventlet/hubs/kqueue.py
@@ -2,7 +2,6 @@ import os
 import sys
 from eventlet import patcher, support
 from eventlet.hubs import hub
-import six
 select = patcher.original('select')
 time = patcher.original('time')
 

--- a/eventlet/hubs/kqueue.py
+++ b/eventlet/hubs/kqueue.py
@@ -19,7 +19,7 @@ class Hub(hub.BaseHub):
             hub.READ: select.KQ_FILTER_READ,
             hub.WRITE: select.KQ_FILTER_WRITE,
         }
-        super(Hub, self).__init__(clock)
+        super().__init__(clock)
         self._events = {}
         self._init_kqueue()
 
@@ -45,7 +45,7 @@ class Hub(hub.BaseHub):
             raise
 
     def add(self, evtype, fileno, cb, tb, mac):
-        listener = super(Hub, self).add(evtype, fileno, cb, tb, mac)
+        listener = super().add(evtype, fileno, cb, tb, mac)
         events = self._events.setdefault(fileno, {})
         if evtype not in events:
             try:
@@ -53,7 +53,7 @@ class Hub(hub.BaseHub):
                 self._control([event], 0, 0)
                 events[evtype] = event
             except ValueError:
-                super(Hub, self).remove(listener)
+                super().remove(listener)
                 raise
         return listener
 
@@ -65,7 +65,7 @@ class Hub(hub.BaseHub):
         self._control(del_events, 0, 0)
 
     def remove(self, listener):
-        super(Hub, self).remove(listener)
+        super().remove(listener)
         evtype = listener.evtype
         fileno = listener.fileno
         if not self.listeners[evtype].get(fileno):
@@ -78,7 +78,7 @@ class Hub(hub.BaseHub):
                 pass
 
     def remove_descriptor(self, fileno):
-        super(Hub, self).remove_descriptor(fileno)
+        super().remove_descriptor(fileno)
         try:
             events = self._events.pop(fileno).values()
             self._delete_events(events)

--- a/eventlet/hubs/poll.py
+++ b/eventlet/hubs/poll.py
@@ -41,12 +41,12 @@ class Hub(hub.BaseHub):
                 else:
                     try:
                         self.poll.modify(fileno, mask)
-                    except (IOError, OSError):
+                    except OSError:
                         self.poll.register(fileno, mask)
             else:
                 try:
                     self.poll.unregister(fileno)
-                except (KeyError, IOError, OSError):
+                except (KeyError, OSError):
                     # raised if we try to remove a fileno that was
                     # already removed/invalid
                     pass
@@ -59,7 +59,7 @@ class Hub(hub.BaseHub):
         super().remove_descriptor(fileno)
         try:
             self.poll.unregister(fileno)
-        except (KeyError, ValueError, IOError, OSError):
+        except (KeyError, ValueError, OSError):
             # raised if we try to remove a fileno that was
             # already removed/invalid
             pass
@@ -78,7 +78,7 @@ class Hub(hub.BaseHub):
             return
         try:
             presult = self.do_poll(seconds)
-        except (IOError, select.error) as e:
+        except (OSError, select.error) as e:
             if support.get_errno(e) == errno.EINTR:
                 return
             raise

--- a/eventlet/hubs/poll.py
+++ b/eventlet/hubs/poll.py
@@ -78,7 +78,7 @@ class Hub(hub.BaseHub):
             return
         try:
             presult = self.do_poll(seconds)
-        except (OSError, select.error) as e:
+        except OSError as e:
             if support.get_errno(e) == errno.EINTR:
                 return
             raise

--- a/eventlet/hubs/poll.py
+++ b/eventlet/hubs/poll.py
@@ -13,19 +13,19 @@ def is_available():
 
 class Hub(hub.BaseHub):
     def __init__(self, clock=None):
-        super(Hub, self).__init__(clock)
+        super().__init__(clock)
         self.EXC_MASK = select.POLLERR | select.POLLHUP
         self.READ_MASK = select.POLLIN | select.POLLPRI
         self.WRITE_MASK = select.POLLOUT
         self.poll = select.poll()
 
     def add(self, evtype, fileno, cb, tb, mac):
-        listener = super(Hub, self).add(evtype, fileno, cb, tb, mac)
+        listener = super().add(evtype, fileno, cb, tb, mac)
         self.register(fileno, new=True)
         return listener
 
     def remove(self, listener):
-        super(Hub, self).remove(listener)
+        super().remove(listener)
         self.register(listener.fileno)
 
     def register(self, fileno, new=False):
@@ -56,7 +56,7 @@ class Hub(hub.BaseHub):
             raise
 
     def remove_descriptor(self, fileno):
-        super(Hub, self).remove_descriptor(fileno)
+        super().remove_descriptor(fileno)
         try:
             self.poll.unregister(fileno)
         except (KeyError, ValueError, IOError, OSError):

--- a/eventlet/hubs/selects.py
+++ b/eventlet/hubs/selects.py
@@ -6,9 +6,9 @@ select = patcher.original('select')
 time = patcher.original('time')
 
 try:
-    BAD_SOCK = set((errno.EBADF, errno.WSAENOTSOCK))
+    BAD_SOCK = {errno.EBADF, errno.WSAENOTSOCK}
 except AttributeError:
-    BAD_SOCK = set((errno.EBADF,))
+    BAD_SOCK = {errno.EBADF}
 
 
 def is_available():
@@ -24,7 +24,7 @@ class Hub(hub.BaseHub):
         for fd in all_fds:
             try:
                 select.select([fd], [], [], 0)
-            except select.error as e:
+            except OSError as e:
                 if support.get_errno(e) in BAD_SOCK:
                     self.remove_descriptor(fd)
 
@@ -40,7 +40,7 @@ class Hub(hub.BaseHub):
         all_fds = reader_fds + writer_fds
         try:
             r, w, er = select.select(reader_fds, writer_fds, all_fds, seconds)
-        except select.error as e:
+        except OSError as e:
             if support.get_errno(e) == errno.EINTR:
                 return
             elif support.get_errno(e) in BAD_SOCK:

--- a/eventlet/hubs/timer.py
+++ b/eventlet/hubs/timer.py
@@ -2,7 +2,7 @@ import traceback
 
 import eventlet.hubs
 from eventlet.support import greenlets as greenlet
-import six
+import io
 
 """ If true, captures a stack trace for each timer when constructed.  This is
 useful for debugging leaking timers, to find out where the timer was set up. """
@@ -24,7 +24,7 @@ class Timer:
         self.tpl = cb, args, kw
         self.called = False
         if _g_debug:
-            self.traceback = six.StringIO()
+            self.traceback = io.StringIO()
             traceback.print_stack(file=self.traceback)
 
     @property

--- a/eventlet/hubs/timer.py
+++ b/eventlet/hubs/timer.py
@@ -9,7 +9,7 @@ useful for debugging leaking timers, to find out where the timer was set up. """
 _g_debug = False
 
 
-class Timer(object):
+class Timer:
     def __init__(self, seconds, cb, *args, **kw):
         """Create a timer.
             seconds: The minimum number of seconds to wait before calling

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -344,24 +344,22 @@ def monkey_patch(**on):
     finally:
         imp.release_lock()
 
-    if sys.version_info >= (3, 3):
-        import importlib._bootstrap
-        thread = original('_thread')
-        # importlib must use real thread locks, not eventlet.Semaphore
-        importlib._bootstrap._thread = thread
+    import importlib._bootstrap
+    thread = original('_thread')
+    # importlib must use real thread locks, not eventlet.Semaphore
+    importlib._bootstrap._thread = thread
 
-        # Issue #185: Since Python 3.3, threading.RLock is implemented in C and
-        # so call a C function to get the thread identifier, instead of calling
-        # threading.get_ident(). Force the Python implementation of RLock which
-        # calls threading.get_ident() and so is compatible with eventlet.
-        import threading
-        threading.RLock = threading._PyRLock
+    # Issue #185: Since Python 3.3, threading.RLock is implemented in C and
+    # so call a C function to get the thread identifier, instead of calling
+    # threading.get_ident(). Force the Python implementation of RLock which
+    # calls threading.get_ident() and so is compatible with eventlet.
+    import threading
+    threading.RLock = threading._PyRLock
 
     # Issue #508: Since Python 3.7 queue.SimpleQueue is implemented in C,
     # causing a deadlock.  Replace the C implementation with the Python one.
-    if sys.version_info >= (3, 7):
-        import queue
-        queue.SimpleQueue = queue._PySimpleQueue
+    import queue
+    queue.SimpleQueue = queue._PySimpleQueue
 
 
 def is_monkey_patched(module):
@@ -491,9 +489,8 @@ def _green_select_modules():
     from eventlet.green import select
     modules = [('select', select)]
 
-    if sys.version_info >= (3, 4):
-        from eventlet.green import selectors
-        modules.append(('selectors', selectors))
+    from eventlet.green import selectors
+    modules.append(('selectors', selectors))
 
     return modules
 

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -16,7 +16,7 @@ import six
 
 __all__ = ['inject', 'import_patched', 'monkey_patch', 'is_monkey_patched']
 
-__exclude = set(('__builtins__', '__file__', '__name__'))
+__exclude = {'__builtins__', '__file__', '__name__'}
 
 
 class SysModulesSaver:
@@ -39,7 +39,7 @@ class SysModulesSaver:
         sys.modules.
         """
         try:
-            for modname, mod in six.iteritems(self._saved):
+            for modname, mod in self._saved.items():
                 if mod is not None:
                     sys.modules[modname] = mod
                 else:
@@ -200,8 +200,7 @@ def original(modname):
     # some special-casing here
     if six.PY2:
         deps = {'threading': 'thread', 'Queue': 'threading'}
-    if six.PY3:
-        deps = {'threading': '_thread', 'queue': 'threading'}
+    deps = {'threading': '_thread', 'queue': 'threading'}
     if modname in deps:
         dependency = deps[modname]
         saver.save(dependency)
@@ -249,9 +248,9 @@ def monkey_patch(**on):
     # the hub calls into monkey-patched modules.
     eventlet.hubs.get_hub()
 
-    accepted_args = set(('os', 'select', 'socket',
-                         'thread', 'time', 'psycopg', 'MySQLdb',
-                         'builtins', 'subprocess'))
+    accepted_args = {'os', 'select', 'socket',
+                     'thread', 'time', 'psycopg', 'MySQLdb',
+                     'builtins', 'subprocess'}
     # To make sure only one of them is passed here
     assert not ('__builtin__' in on and 'builtins' in on)
     try:
@@ -263,7 +262,7 @@ def monkey_patch(**on):
 
     default_on = on.pop("all", None)
 
-    for k in six.iterkeys(on):
+    for k in on.keys():
         if k not in accepted_args:
             raise TypeError("monkey_patch() got an unexpected "
                             "keyword argument %r" % k)
@@ -522,8 +521,7 @@ def _green_thread_modules():
     from eventlet.green import threading
     if six.PY2:
         return [('Queue', Queue), ('thread', thread), ('threading', threading)]
-    if six.PY3:
-        return [('queue', Queue), ('_thread', thread), ('threading', threading)]
+    return [('queue', Queue), ('_thread', thread), ('threading', threading)]
 
 
 def _green_time_modules():
@@ -557,11 +555,11 @@ def slurp_properties(source, destination, ignore=[], srckeys=None):
     """
     if srckeys is None:
         srckeys = source.__all__
-    destination.update(dict([
-        (name, getattr(source, name))
+    destination.update({
+        name: getattr(source, name)
         for name in srckeys
         if not (name.startswith('__') or name in ignore)
-    ]))
+    })
 
 
 if __name__ == "__main__":

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -19,7 +19,7 @@ __all__ = ['inject', 'import_patched', 'monkey_patch', 'is_monkey_patched']
 __exclude = set(('__builtins__', '__file__', '__name__'))
 
 
-class SysModulesSaver(object):
+class SysModulesSaver:
     """Class that captures some subset of the current state of
     sys.modules.  Pass in an iterator of module names to the
     constructor."""

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -11,7 +11,6 @@ except ImportError:
     register_at_fork = None
 
 import eventlet
-import six
 
 
 __all__ = ['inject', 'import_patched', 'monkey_patch', 'is_monkey_patched']
@@ -198,8 +197,6 @@ def original(modname):
     # some rudimentary dependency checking -- fortunately the modules
     # we're working on don't have many dependencies so we can just do
     # some special-casing here
-    if six.PY2:
-        deps = {'threading': 'thread', 'Queue': 'threading'}
     deps = {'threading': '_thread', 'queue': 'threading'}
     if modname in deps:
         dependency = deps[modname]
@@ -519,8 +516,6 @@ def _green_thread_modules():
     from eventlet.green import Queue
     from eventlet.green import thread
     from eventlet.green import threading
-    if six.PY2:
-        return [('Queue', Queue), ('thread', thread), ('threading', threading)]
     return [('queue', Queue), ('_thread', thread), ('threading', threading)]
 
 
@@ -540,7 +535,7 @@ def _green_MySQLdb():
 def _green_builtins():
     try:
         from eventlet.green import builtin
-        return [('__builtin__' if six.PY2 else 'builtins', builtin)]
+        return [('builtins', builtin)]
     except ImportError:
         return []
 

--- a/eventlet/pools.py
+++ b/eventlet/pools.py
@@ -9,7 +9,7 @@ from eventlet import queue
 __all__ = ['Pool', 'TokenPool']
 
 
-class Pool(object):
+class Pool:
     """
     Pool class implements resource limitation and construction.
 
@@ -172,7 +172,7 @@ class Pool(object):
         raise NotImplementedError("Implement in subclass")
 
 
-class Token(object):
+class Token:
     pass
 
 

--- a/eventlet/pools.py
+++ b/eventlet/pools.py
@@ -1,4 +1,3 @@
-
 import collections
 from contextlib import contextmanager
 

--- a/eventlet/pools.py
+++ b/eventlet/pools.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import collections
 from contextlib import contextmanager

--- a/eventlet/queue.py
+++ b/eventlet/queue.py
@@ -39,7 +39,6 @@ or :meth:`Queue.put` will not block.  The new methods :meth:`Queue.getting`
 and :meth:`Queue.putting` report on the number of greenthreads blocking
 in :meth:`put <Queue.put>` or :meth:`get <Queue.get>` respectively.
 """
-from __future__ import print_function
 
 import sys
 import heapq

--- a/eventlet/queue.py
+++ b/eventlet/queue.py
@@ -49,7 +49,7 @@ from eventlet.event import Event
 from eventlet.greenthread import getcurrent
 from eventlet.hubs import get_hub
 import six
-from six.moves import queue as Stdlib_Queue
+import queue as Stdlib_Queue
 from eventlet.timeout import Timeout
 
 

--- a/eventlet/queue.py
+++ b/eventlet/queue.py
@@ -61,7 +61,7 @@ Full = six.moves.queue.Full
 Empty = six.moves.queue.Empty
 
 
-class Waiter(object):
+class Waiter:
     """A low level synchronization class.
 
     Wrapper around greenlet's ``switch()`` and ``throw()`` calls that makes them safe:
@@ -143,7 +143,7 @@ class Waiter(object):
             self.greenlet = None
 
 
-class LightQueue(object):
+class LightQueue:
     """
     This is a variant of Queue that behaves mostly like the standard
     :class:`Stdlib_Queue`.  It differs by not supporting the

--- a/eventlet/queue.py
+++ b/eventlet/queue.py
@@ -48,7 +48,6 @@ import traceback
 from eventlet.event import Event
 from eventlet.greenthread import getcurrent
 from eventlet.hubs import get_hub
-import six
 import queue as Stdlib_Queue
 from eventlet.timeout import Timeout
 
@@ -56,8 +55,8 @@ from eventlet.timeout import Timeout
 __all__ = ['Queue', 'PriorityQueue', 'LifoQueue', 'LightQueue', 'Full', 'Empty']
 
 _NONE = object()
-Full = six.moves.queue.Full
-Empty = six.moves.queue.Empty
+Full = Stdlib_Queue.Full
+Empty = Stdlib_Queue.Empty
 
 
 class Waiter:

--- a/eventlet/semaphore.py
+++ b/eventlet/semaphore.py
@@ -176,7 +176,7 @@ class BoundedSemaphore(Semaphore):
     """
 
     def __init__(self, value=1):
-        super(BoundedSemaphore, self).__init__(value)
+        super().__init__(value)
         self.original_counter = value
 
     def release(self, blocking=True):
@@ -190,7 +190,7 @@ class BoundedSemaphore(Semaphore):
         """
         if self.counter >= self.original_counter:
             raise ValueError("Semaphore released too many times")
-        return super(BoundedSemaphore, self).release(blocking)
+        return super().release(blocking)
 
 
 class CappedSemaphore:

--- a/eventlet/semaphore.py
+++ b/eventlet/semaphore.py
@@ -34,10 +34,10 @@ class Semaphore:
         try:
             value = int(value)
         except ValueError as e:
-            msg = 'Semaphore() expect value :: int, actual: {0} {1}'.format(type(value), str(e))
+            msg = 'Semaphore() expect value :: int, actual: {} {}'.format(type(value), str(e))
             raise TypeError(msg)
         if value < 0:
-            msg = 'Semaphore() expect value >= 0, actual: {0}'.format(repr(value))
+            msg = 'Semaphore() expect value >= 0, actual: {}'.format(repr(value))
             raise ValueError(msg)
         self.counter = value
         self._waiters = collections.deque()

--- a/eventlet/semaphore.py
+++ b/eventlet/semaphore.py
@@ -4,7 +4,7 @@ import eventlet
 from eventlet import hubs
 
 
-class Semaphore(object):
+class Semaphore:
 
     """An unbounded semaphore.
     Optionally initialize with a resource *count*, then :meth:`acquire` and
@@ -193,7 +193,7 @@ class BoundedSemaphore(Semaphore):
         return super(BoundedSemaphore, self).release(blocking)
 
 
-class CappedSemaphore(object):
+class CappedSemaphore:
 
     """A blockingly bounded semaphore.
 

--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -98,7 +98,7 @@ if (os.environ.get('EVENTLET_DEPRECATED_EAI_NODATA', '').lower() in ('1', 'y', '
 
 def is_ipv4_addr(host):
     """Return True if host is a valid IPv4 address"""
-    if not isinstance(host, six.string_types):
+    if not isinstance(host, str):
         return False
     try:
         dns.ipv4.inet_aton(host)
@@ -110,7 +110,7 @@ def is_ipv4_addr(host):
 
 def is_ipv6_addr(host):
     """Return True if host is a valid IPv6 address"""
-    if not isinstance(host, six.string_types):
+    if not isinstance(host, str):
         return False
     host = host.split('%', 1)[0]
     try:
@@ -211,7 +211,7 @@ class HostsResolver:
 
         udata = fdata.decode(errors='ignore')
 
-        return six.moves.filter(None, self.LINES_RE.findall(udata))
+        return filter(None, self.LINES_RE.findall(udata))
 
     def _load(self):
         """Load hosts file
@@ -262,10 +262,10 @@ class HostsResolver:
         if self._last_load + self.interval < now:
             self._load()
         rdclass = dns.rdataclass.IN
-        if isinstance(qname, six.string_types):
+        if isinstance(qname, str):
             name = qname
             qname = dns.name.from_text(qname)
-        elif isinstance(qname, six.binary_type):
+        elif isinstance(qname, bytes):
             name = qname.decode("ascii")
             qname = dns.name.from_text(qname)
         else:
@@ -305,7 +305,7 @@ class HostsResolver:
         else:
             cannon = hostname
         aliases.append(cannon)
-        for alias, cname in six.iteritems(self._aliases):
+        for alias, cname in self._aliases.items():
             if cannon == cname:
                 aliases.append(alias)
         aliases.remove(hostname)
@@ -367,7 +367,7 @@ class ResolverProxy:
 
         if qname is None:
             qname = '0.0.0.0'
-        if isinstance(qname, six.string_types) or isinstance(qname, six.binary_type):
+        if isinstance(qname, str) or isinstance(qname, bytes):
             qname = dns.name.from_text(qname, None)
 
         def step(fun, *args, **kwargs):
@@ -546,9 +546,9 @@ def getaddrinfo(host, port, family=0, socktype=0, proto=0, flags=0):
     flag ensures getaddrinfo(3) does not use the network itself and
     allows us to respect all the other arguments like the native OS.
     """
-    if isinstance(host, six.string_types):
+    if isinstance(host, str):
         host = host.encode('idna').decode('ascii')
-    elif isinstance(host, six.binary_type):
+    elif isinstance(host, bytes):
         host = host.decode("ascii")
     if host is not None and not is_ip_addr(host):
         qname, addrs = _getaddrinfo_lookup(host, family, flags)
@@ -562,7 +562,7 @@ def getaddrinfo(host, port, family=0, socktype=0, proto=0, flags=0):
         try:
             ai = socket.getaddrinfo(addr, port, family,
                                     socktype, proto, aiflags)
-        except socket.error as e:
+        except OSError as e:
             if flags & socket.AI_ADDRCONFIG:
                 err = e
                 continue
@@ -626,7 +626,7 @@ def getnameinfo(sockaddr, flags):
             rrset = resolver.query(
                 dns.reversename.from_address(host), dns.rdatatype.PTR)
             if len(rrset) > 1:
-                raise socket.error('sockaddr resolved to multiple addresses')
+                raise OSError('sockaddr resolved to multiple addresses')
             host = rrset[0].target.to_text(omit_final_dot=True)
         except dns.exception.Timeout:
             if flags & socket.NI_NAMEREQD:
@@ -638,7 +638,7 @@ def getnameinfo(sockaddr, flags):
         try:
             rrset = resolver.query(host)
             if len(rrset) > 1:
-                raise socket.error('sockaddr resolved to multiple addresses')
+                raise OSError('sockaddr resolved to multiple addresses')
             if flags & socket.NI_NUMERICHOST:
                 host = rrset[0].address
         except dns.exception.Timeout:

--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -206,7 +206,7 @@ class HostsResolver:
         try:
             with open(self.fname, 'rb') as fp:
                 fdata = fp.read()
-        except (IOError, OSError):
+        except OSError:
             return []
 
         udata = fdata.decode(errors='ignore')

--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -161,7 +161,7 @@ class HostsAnswer(dns.resolver.Answer):
                            rrset.ttl if hasattr(rrset, 'ttl') else 0)
 
 
-class HostsResolver(object):
+class HostsResolver:
     """Class to parse the hosts file
 
     Attributes
@@ -312,7 +312,7 @@ class HostsResolver(object):
         return aliases
 
 
-class ResolverProxy(object):
+class ResolverProxy:
     """Resolver class which can also use /etc/hosts
 
     Initialise with a HostsResolver instance in order for it to also

--- a/eventlet/support/greendns.py
+++ b/eventlet/support/greendns.py
@@ -43,7 +43,6 @@ from eventlet.green import os
 from eventlet.green import time
 from eventlet.green import select
 from eventlet.green import ssl
-import six
 
 
 def import_patched(module_name):

--- a/eventlet/support/stacklesss.py
+++ b/eventlet/support/stacklesss.py
@@ -17,7 +17,7 @@ def getcurrent():
     return tasklet_to_greenlet[stackless.getcurrent()]
 
 
-class FirstSwitch(object):
+class FirstSwitch:
     def __init__(self, gr):
         self.gr = gr
 
@@ -33,7 +33,7 @@ class FirstSwitch(object):
         t.run()
 
 
-class greenlet(object):
+class greenlet:
     def __init__(self, run=None, parent=None):
         self.dead = False
         if parent is None:

--- a/eventlet/tpool.py
+++ b/eventlet/tpool.py
@@ -24,7 +24,6 @@ import traceback
 
 import eventlet
 from eventlet import event, greenio, greenthread, patcher, timeout
-import six
 
 __all__ = ['execute', 'Proxy', 'killall', 'set_num_threads']
 
@@ -87,8 +86,6 @@ def tworker():
             rv = sys.exc_info()
             if sys.version_info >= (3, 4):
                 traceback.clear_frames(rv[1].__traceback__)
-        if six.PY2:
-            sys.exc_clear()
         # test_leakage_from_tracebacks verifies that the use of
         # exc_info does not lead to memory leaks
         _rspq.put((e, rv))

--- a/eventlet/tpool.py
+++ b/eventlet/tpool.py
@@ -36,10 +36,7 @@ QUIET = True
 
 socket = patcher.original('socket')
 threading = patcher.original('threading')
-if six.PY2:
-    Queue_module = patcher.original('Queue')
-if six.PY3:
-    Queue_module = patcher.original('queue')
+Queue_module = patcher.original('queue')
 
 Empty = Queue_module.Empty
 Queue = Queue_module.Queue
@@ -129,7 +126,7 @@ def execute(meth, *args, **kwargs):
         if not QUIET:
             traceback.print_exception(c, e, tb)
             traceback.print_stack()
-        six.reraise(c, e, tb)
+        raise e.with_traceback(tb)
     return rv
 
 
@@ -289,7 +286,7 @@ def setup():
     _rsock = greenio.GreenSocket(csock)
     _rsock.settimeout(None)
 
-    for i in six.moves.range(_nthreads):
+    for i in range(_nthreads):
         t = threading.Thread(target=tworker,
                              name="tpool_thread_%s" % i)
         t.daemon = True

--- a/eventlet/tpool.py
+++ b/eventlet/tpool.py
@@ -84,8 +84,7 @@ def tworker():
             raise
         except EXC_CLASSES:
             rv = sys.exc_info()
-            if sys.version_info >= (3, 4):
-                traceback.clear_frames(rv[1].__traceback__)
+            traceback.clear_frames(rv[1].__traceback__)
         # test_leakage_from_tracebacks verifies that the use of
         # exc_info does not lead to memory leaks
         _rspq.put((e, rv))

--- a/eventlet/tpool.py
+++ b/eventlet/tpool.py
@@ -155,7 +155,7 @@ def proxy_call(autowrap, f, *args, **kwargs):
         return rv
 
 
-class Proxy(object):
+class Proxy:
     """
     a simple proxy-wrapper of any object that comes with a
     methods-only interface, in order to forward every method

--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -475,7 +475,7 @@ class WebSocket:
         if self.version == 76 and not self.websocket_closed:
             try:
                 self.socket.sendall(b"\xff\x00")
-            except SocketError:
+            except OSError:
                 # Sometimes, like when the remote side cuts off the connection,
                 # we don't care about this.
                 if not ignore_send_errors:  # pragma NO COVER
@@ -488,7 +488,7 @@ class WebSocket:
         try:
             self._send_closing_frame(True)
             self.socket.shutdown(True)
-        except SocketError as e:
+        except OSError as e:
             if e.errno != errno.ENOTCONN:
                 self.log.write('{ctx} socket shutdown error: {e}'.format(ctx=self.log_context, e=e))
         finally:
@@ -844,7 +844,7 @@ class RFC6455WebSocket(WebSocket):
                 data = ''
             try:
                 self.send(data, control_code=8)
-            except SocketError:
+            except OSError:
                 # Sometimes, like when the remote side cuts off the connection,
                 # we don't care about this.
                 if not ignore_send_errors:  # pragma NO COVER
@@ -857,7 +857,7 @@ class RFC6455WebSocket(WebSocket):
         try:
             self._send_closing_frame(close_data=close_data, ignore_send_errors=True)
             self.socket.shutdown(socket.SHUT_WR)
-        except SocketError as e:
+        except OSError as e:
             if e.errno != errno.ENOTCONN:
                 self.log.write('{ctx} socket shutdown error: {e}'.format(ctx=self.log_context, e=e))
         finally:

--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -501,7 +501,7 @@ class ConnectionClosedError(Exception):
 
 class FailedConnectionError(Exception):
     def __init__(self, status, message):
-        super(FailedConnectionError, self).__init__(status, message)
+        super().__init__(status, message)
         self.message = message
         self.status = status
 
@@ -513,7 +513,7 @@ class ProtocolError(ValueError):
 class RFC6455WebSocket(WebSocket):
     def __init__(self, sock, environ, version=13, protocol=None, client=False, extensions=None,
                  max_frame_length=DEFAULT_MAX_FRAME_LENGTH):
-        super(RFC6455WebSocket, self).__init__(sock, environ, version)
+        super().__init__(sock, environ, version)
         self.iterator = self._iter_frames()
         self.client = client
         self.protocol = protocol

--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -62,7 +62,7 @@ class BadRequest(Exception):
         self.headers = headers
 
 
-class WebSocketWSGI(object):
+class WebSocketWSGI:
     """Wraps a websocket handler function in a WSGI application.
 
     Use it like this::
@@ -349,7 +349,7 @@ class WebSocketWSGI(object):
         return int(out) // spaces
 
 
-class WebSocket(object):
+class WebSocket:
     """A websocket object that handles the details of
     serialization/deserialization to the socket.
 
@@ -524,7 +524,7 @@ class RFC6455WebSocket(WebSocket):
         self.max_frame_length = max_frame_length
         self._remote_close_data = None
 
-    class UTF8Decoder(object):
+    class UTF8Decoder:
         def __init__(self):
             if utf8validator:
                 self.validator = utf8validator.Utf8Validator()
@@ -593,7 +593,7 @@ class RFC6455WebSocket(WebSocket):
             data = data + d
         return data
 
-    class Message(object):
+    class Message:
         def __init__(self, opcode, max_frame_length, decoder=None, decompressor=None):
             self.decoder = decoder
             self.data = []

--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -374,7 +374,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
             else:
                 # it's a SSLObject, or a martian
                 raise NotImplementedError(
-                    '''eventlet.wsgi doesn't support sockets of type {0}'''.format(type(conn)))
+                    '''eventlet.wsgi doesn't support sockets of type {}'''.format(type(conn)))
 
     def handle(self):
         self.close_connection = True
@@ -403,7 +403,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
         except socket.error as e:
             last_errno = support.get_errno(e)
             if last_errno in BROKEN_SOCK:
-                self.server.log.debug('({0}) connection reset by peer {1!r}'.format(
+                self.server.log.debug('({}) connection reset by peer {!r}'.format(
                     self.server.pid,
                     self.client_address))
             elif last_errno not in BAD_SOCK:
@@ -848,7 +848,7 @@ class Server(BaseHTTPServer.HTTPServer):
             # Expected exceptions are not exceptional
             conn_state[1].close()
             # similar to logging "accepted" in server()
-            self.log.debug('({0}) timed out {1!r}'.format(self.pid, conn_state[0]))
+            self.log.debug('({}) timed out {!r}'.format(self.pid, conn_state[0]))
 
     def log_message(self, message):
         raise AttributeError('''\
@@ -879,9 +879,9 @@ def socket_repr(sock):
 
     name = sock.getsockname()
     if sock.family == socket.AF_INET:
-        hier_part = '//{0}:{1}'.format(*name)
+        hier_part = '//{}:{}'.format(*name)
     elif sock.family == socket.AF_INET6:
-        hier_part = '//[{0}]:{1}'.format(*name[:2])
+        hier_part = '//[{}]:{}'.format(*name[:2])
     elif sock.family == socket.AF_UNIX:
         hier_part = name
     else:
@@ -1006,12 +1006,12 @@ If unsure, use eventlet.GreenPool.''')
         conn[1].close()
 
     try:
-        serv.log.info('({0}) wsgi starting up on {1}'.format(serv.pid, socket_repr(sock)))
+        serv.log.info('({}) wsgi starting up on {}'.format(serv.pid, socket_repr(sock)))
         while is_accepting:
             try:
                 client_socket, client_addr = sock.accept()
                 client_socket.settimeout(serv.socket_timeout)
-                serv.log.debug('({0}) accepted {1!r}'.format(serv.pid, client_addr))
+                serv.log.debug('({}) accepted {!r}'.format(serv.pid, client_addr))
                 connections[client_addr] = connection = [client_addr, client_socket, STATE_IDLE]
                 (pool.spawn(serv.process_request, connection)
                     .link(_clean_connection, connection))
@@ -1028,7 +1028,7 @@ If unsure, use eventlet.GreenPool.''')
             if prev_state == STATE_IDLE:
                 greenio.shutdown_safe(cs[1])
         pool.waitall()
-        serv.log.info('({0}) wsgi exited, is_accepting={1}'.format(serv.pid, is_accepting))
+        serv.log.info('({}) wsgi exited, is_accepting={}'.format(serv.pid, is_accepting))
         try:
             # NOTE: It's not clear whether we want this to leave the
             # socket open or close it.  Use cases like Spawning want

--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -73,7 +73,7 @@ class ChunkReadError(ValueError):
 WSGI_LOCAL = local()
 
 
-class Input(object):
+class Input:
 
     def __init__(self,
                  rfile,
@@ -272,7 +272,7 @@ def get_logger(log, debug):
         return LoggerFileWrapper(log or sys.stderr, debug)
 
 
-class LoggerNull(object):
+class LoggerNull:
     def __init__(self):
         pass
 
@@ -311,7 +311,7 @@ class LoggerFileWrapper(LoggerNull):
         self.log.write(msg)
 
 
-class FileObjectForHeaders(object):
+class FileObjectForHeaders:
 
     def __init__(self, fp):
         self.fp = fp

--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -182,7 +182,7 @@ class Input:
                     data = reader(maxreadlen)
                     if not data:
                         self.chunk_length = 0
-                        raise IOError("unexpected end of file while parsing chunked data")
+                        raise OSError("unexpected end of file while parsing chunked data")
 
                     datalen = len(data)
                     response.append(data)
@@ -652,7 +652,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
                             + ' client={0} request="{1}" error="{2}"').format(
                                 self.get_client_address()[0], self.requestline, e,
                         ))
-                    except IOError as e:
+                    except OSError as e:
                         self.close_connection = 1
                         self.server.log.error((
                             'I/O error while discarding request body.'

--- a/eventlet/zipkin/api.py
+++ b/eventlet/zipkin/api.py
@@ -89,7 +89,7 @@ def generate_span_id():
     return _uniq_id()
 
 
-class TraceData(object):
+class TraceData:
 
     END_ANNOTATION = SERVER_SEND
 

--- a/eventlet/zipkin/client.py
+++ b/eventlet/zipkin/client.py
@@ -11,7 +11,7 @@ from eventlet import GreenPile
 CATEGORY = 'zipkin'
 
 
-class ZipkinClient(object):
+class ZipkinClient:
 
     def __init__(self, host='127.0.0.1', port=9410):
         """

--- a/eventlet/zipkin/http.py
+++ b/eventlet/zipkin/http.py
@@ -12,35 +12,11 @@ HDR_PARENT_SPAN_ID = 'X-B3-ParentSpanId'
 HDR_SAMPLED = 'X-B3-Sampled'
 
 
-if six.PY2:
-    __org_endheaders__ = httplib.HTTPConnection.endheaders
-    __org_begin__ = httplib.HTTPResponse.begin
-
-    def _patched_endheaders(self):
-        if api.is_tracing():
-            trace_data = api.get_trace_data()
-            new_span_id = api.generate_span_id()
-            self.putheader(HDR_TRACE_ID, hex_str(trace_data.trace_id))
-            self.putheader(HDR_SPAN_ID, hex_str(new_span_id))
-            self.putheader(HDR_PARENT_SPAN_ID, hex_str(trace_data.span_id))
-            self.putheader(HDR_SAMPLED, int(trace_data.sampled))
-            api.put_annotation('Client Send')
-
-        __org_endheaders__(self)
-
-    def _patched_begin(self):
-        __org_begin__(self)
-
-        if api.is_tracing():
-            api.put_annotation('Client Recv (%s)' % self.status)
-
-
 def patch():
     if six.PY2:
         httplib.HTTPConnection.endheaders = _patched_endheaders
         httplib.HTTPResponse.begin = _patched_begin
-    if six.PY3:
-        warnings.warn("Since current Python thrift release \
+    warnings.warn("Since current Python thrift release \
         doesn't support Python 3, eventlet.zipkin.http \
         doesn't also support Python 3 (http.client)")
 
@@ -49,8 +25,7 @@ def unpatch():
     if six.PY2:
         httplib.HTTPConnection.endheaders = __org_endheaders__
         httplib.HTTPResponse.begin = __org_begin__
-    if six.PY3:
-        pass
+    pass
 
 
 def hex_str(n):

--- a/eventlet/zipkin/http.py
+++ b/eventlet/zipkin/http.py
@@ -1,6 +1,5 @@
 import warnings
 
-import six
 from eventlet.green import httplib
 from eventlet.zipkin import api
 
@@ -13,18 +12,12 @@ HDR_SAMPLED = 'X-B3-Sampled'
 
 
 def patch():
-    if six.PY2:
-        httplib.HTTPConnection.endheaders = _patched_endheaders
-        httplib.HTTPResponse.begin = _patched_begin
     warnings.warn("Since current Python thrift release \
         doesn't support Python 3, eventlet.zipkin.http \
         doesn't also support Python 3 (http.client)")
 
 
 def unpatch():
-    if six.PY2:
-        httplib.HTTPConnection.endheaders = __org_endheaders__
-        httplib.HTTPResponse.begin = __org_begin__
     pass
 
 

--- a/eventlet/zipkin/wsgi.py
+++ b/eventlet/zipkin/wsgi.py
@@ -40,7 +40,7 @@ def _patched_handle_one_response(self):
         api.put_annotation(SERVER_SEND)
 
 
-class Sampler(object):
+class Sampler:
     def __init__(self, sampling_rate):
         self.sampling_rate = sampling_rate
 


### PR DESCRIPTION
@jayofdoom successfully nerdsniped me, so I nerdsniped him back by teaching him about pyupgrade and ruff for automated migration. Here's a nice chunk of changes, which has the advantage of dropping a dependency on the "six" module.

Automatically upgrade code to drop python2 specific logic. Done in three passes:
- automatically run `pyupgrade --py3-only --keep-percent-format` on all files, to update to python 3.0 without changing percent formatting to `.format()` (this would be fairly noisy and isn't even 100% desired by everyone)
- manually fix up a bunch of six specific stuff, mainly dropping unused "import six" left behind by pyupgrade, and drop six from install requires.
- switch over to `ruff check` with its `--select UP*` class of rules targeting py37, and apply autofixes.