### PR TITLE
Ignore asyncore and asynchat for Python 3.12+

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Unreleased
+==========
+
+* Ignore asyncore and asynchat for Python 3.12+ https://github.com/eventlet/eventlet/issues/804
+
 0.34.0
 ======
 

--- a/eventlet/green/asynchat.py
+++ b/eventlet/green/asynchat.py
@@ -1,11 +1,14 @@
-from eventlet import patcher
-from eventlet.green import asyncore
-from eventlet.green import socket
+import sys
 
-patcher.inject(
-    'asynchat',
-    globals(),
-    ('asyncore', asyncore),
-    ('socket', socket))
+if sys.version_info < (3, 12):
+    from eventlet import patcher
+    from eventlet.green import asyncore
+    from eventlet.green import socket
 
-del patcher
+    patcher.inject(
+        'asynchat',
+        globals(),
+        ('asyncore', asyncore),
+        ('socket', socket))
+
+    del patcher

--- a/eventlet/green/asyncore.py
+++ b/eventlet/green/asyncore.py
@@ -1,13 +1,16 @@
-from eventlet import patcher
-from eventlet.green import select
-from eventlet.green import socket
-from eventlet.green import time
+import sys
 
-patcher.inject(
-    "asyncore",
-    globals(),
-    ('select', select),
-    ('socket', socket),
-    ('time', time))
+if sys.version_info < (3, 12):
+    from eventlet import patcher
+    from eventlet.green import select
+    from eventlet.green import socket
+    from eventlet.green import time
 
-del patcher
+    patcher.inject(
+        "asyncore",
+        globals(),
+        ('select', select),
+        ('socket', socket),
+        ('time', time))
+
+    del patcher


### PR DESCRIPTION
Starting Python 3.12 these modules have been removed

https://docs.python.org/3/whatsnew/3.12.html

Fix #804