### PR TITLE
Fix OIDC authentication failure

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,7 @@ name: Build & Optional Deploy
 on: [push, pull_request]
 
 permissions:
-  contents: read
+  id-token: write
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
The publish job require writing permissions to store the `id-token` requested by Pypi.

Without that change, we will get the following error:

> Trusted publishing exchange failure:
> OpenID Connect token retrieval failed: GitHub: missing or insufficient
> OIDC token permissions, the ACTIONS_ID_TOKEN_REQUEST_TOKEN environment
> variable was unset

> This generally indicates a workflow configuration error, such as
> insufficient permissions. Make sure that your workflow has `id-token: write`
> configured at the job level, e.g.:

Learn more at:
https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings.