### PR TITLE
Skip test which uses Py cgi module

### DIFF
--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -675,6 +675,7 @@ class TestHttpd(_TestBase):
                         reason="cgi deprecated since version 3.11, will be removed in version 3.13")
     def test_019_fieldstorage_compat(self):
         import cgi
+        
         def use_fieldstorage(environ, start_response):
             cgi.FieldStorage(fp=environ['wsgi.input'], environ=environ)
             start_response('200 OK', [('Content-type', 'text/plain')])

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -675,7 +675,7 @@ class TestHttpd(_TestBase):
                         reason="cgi deprecated since version 3.11, will be removed in version 3.13")
     def test_019_fieldstorage_compat(self):
         import cgi
-        
+
         def use_fieldstorage(environ, start_response):
             cgi.FieldStorage(fp=environ['wsgi.input'], environ=environ)
             start_response('200 OK', [('Content-type', 'text/plain')])

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -1,8 +1,8 @@
-import cgi
 import collections
 import errno
 import io
 import os
+import pytest
 import shutil
 import signal
 import socket
@@ -671,7 +671,10 @@ class TestHttpd(_TestBase):
 
         sock.close()
 
+    @pytest.mark.skipif(sys.version_info >= (3, 11),
+                        reason="cgi deprecated since version 3.11, will be removed in version 3.13")
     def test_019_fieldstorage_compat(self):
+        import cgi
         def use_fieldstorage(environ, start_response):
             cgi.FieldStorage(fp=environ['wsgi.input'], environ=environ)
             start_response('200 OK', [('Content-type', 'text/plain')])

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -671,7 +671,7 @@ class TestHttpd(_TestBase):
 
         sock.close()
 
-    @pytest.mark.skipif(sys.version_info >= (3, 11),
+    @pytest.mark.skipif(sys.version_info[:2] >= (3, 11),
                         reason="cgi deprecated since version 3.11, will be removed in version 3.13")
     def test_019_fieldstorage_compat(self):
         import cgi


### PR DESCRIPTION
Python cgi module has been deprecated since version 3.11, and will be removed in version 3.13. Skip test_019_fieldstorage_compat test if Py >= 3.11.

Fixes https://github.com/eventlet/eventlet/issues/863