### PR TITLE
No more segfaults: a new approach for greening existing locks

### DIFF
--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -403,8 +403,10 @@ def _green_existing_locks():
     # general, this is difficult to ensure, so just don't complain in that case.
     if "PYTEST_CURRENT_TEST" in os.environ:
         return
-    # We don't want to use gc.get_objects() to find locks because that doesn't
-    # work in older Python, but it's fine for logging purposes.
+    # On older Pythons (< 3.10), gc.get_objects() won't return any RLock
+    # instances, so this warning won't get logged on older Pythons. However,
+    # it's a useful warning, so we try to do it anyway for the benefit of those
+    # users on 3.10 or later.
     gc.collect()
     remaining_rlocks = len({o for o in gc.get_objects() if isinstance(o, rlock_type)})
     if remaining_rlocks:

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -404,7 +404,7 @@ def _green_existing_locks():
     # We don't want to use gc.get_objects() to find locks because that doesn't
     # work in older Python, but it's fine for logging purposes.
     gc.collect()
-    remaining_rlocks = {o for o in gc.get_objects() if isinstance(o, rlock_type)}
+    remaining_rlocks = len({o for o in gc.get_objects() if isinstance(o, rlock_type)})
     if remaining_rlocks:
         import logging
         logger = logging.Logger("eventlet")
@@ -417,6 +417,9 @@ def _find_instances(container, klass, visited=None, found=None):
     """
     Starting with a Python object, find all instances of ``klass``, following
     references in ``dict`` values, ``list`` items, and attributes.
+
+    In practice this is used only for ``threading.RLock``, so we can assume
+    instances are hashable.
     """
     if visited is None:
         visited = {}  # map id(obj) to obj

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -384,6 +384,7 @@ def _green_existing_locks():
 
     This was originally noticed in the stdlib logging module."""
     import gc
+    import os
     import threading
     import eventlet.green.thread
     rlock_type = type(threading.RLock())
@@ -395,6 +396,11 @@ def _green_existing_locks():
         _fix_py3_rlock(obj, tid)
         del obj
 
+    # Report if there are RLocks we couldn't upgrade. For cases where we're
+    # using coverage.py in parent process, and more generally for tests in
+    # general, this is difficult to ensure, so just don't complain in that case.
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        return
     # We don't want to use gc.get_objects() to find locks because that doesn't
     # work in older Python, but it's fine for logging purposes.
     gc.collect()

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Callable, Optional
 try:
     import _imp as imp
 except ImportError:

--- a/tests/isolated/patcher_existing_locks_preexisting.py
+++ b/tests/isolated/patcher_existing_locks_preexisting.py
@@ -1,0 +1,37 @@
+"""
+Ensure pre-existing RLocks get upgraded in a variety of situations.
+"""
+
+import threading
+import unittest.mock
+import eventlet
+
+python_lock = threading._PyRLock
+
+class NS:
+    lock = threading.RLock()
+
+    class NS2:
+        lock = threading.RLock()
+
+    dict = {1: 2, 12: threading.RLock()}
+    list = [0, threading.RLock()]
+
+
+def ensure_upgraded(lock):
+    if not isinstance(lock, python_lock):
+        raise RuntimeError(lock)
+
+
+if __name__ == '__main__':
+    # These extra print()s caused either test failures or segfaults until
+    # https://github.com/eventlet/eventlet/issues/864 was fixed.
+    print(unittest.mock.NonCallableMock._lock)
+    print(NS.lock)
+    eventlet.monkey_patch()
+    ensure_upgraded(NS.lock)
+    ensure_upgraded(NS.NS2.lock)
+    ensure_upgraded(NS.dict[12])
+    ensure_upgraded(NS.list[1])
+    ensure_upgraded(unittest.mock.NonCallableMock._lock)
+    print("pass")

--- a/tests/isolated/patcher_existing_locks_preexisting.py
+++ b/tests/isolated/patcher_existing_locks_preexisting.py
@@ -9,6 +9,7 @@ import eventlet
 
 python_lock = threading._PyRLock
 
+
 class NS:
     lock = threading.RLock()
 

--- a/tests/isolated/patcher_existing_locks_preexisting.py
+++ b/tests/isolated/patcher_existing_locks_preexisting.py
@@ -2,6 +2,7 @@
 Ensure pre-existing RLocks get upgraded in a variety of situations.
 """
 
+import sys
 import threading
 import unittest.mock
 import eventlet
@@ -26,12 +27,14 @@ def ensure_upgraded(lock):
 if __name__ == '__main__':
     # These extra print()s caused either test failures or segfaults until
     # https://github.com/eventlet/eventlet/issues/864 was fixed.
-    print(unittest.mock.NonCallableMock._lock)
+    if sys.version_info[:2] > (3, 9):
+        print(unittest.mock.NonCallableMock._lock)
     print(NS.lock)
     eventlet.monkey_patch()
     ensure_upgraded(NS.lock)
     ensure_upgraded(NS.NS2.lock)
     ensure_upgraded(NS.dict[12])
     ensure_upgraded(NS.list[1])
-    ensure_upgraded(unittest.mock.NonCallableMock._lock)
+    if sys.version_info[:2] > (3, 9):
+        ensure_upgraded(unittest.mock.NonCallableMock._lock)
     print("pass")

--- a/tests/patcher_test.py
+++ b/tests/patcher_test.py
@@ -523,3 +523,7 @@ def test_builtin():
 
 def test_open_kwargs():
     tests.run_isolated("patcher_open_kwargs.py")
+
+
+def test_patcher_existing_locks():
+    tests.run_isolated("patcher_existing_locks_preexisting.py")


### PR DESCRIPTION
1. Works better on older Python 3.
2. Doesn't cause segfaults!!!!
3. Somewhat worse in terms of finding RLocks than what we had before, but in practice unlikely to be an issue.
4. Adds a warning about unupgraded RLocks.
5. Improved test coverage.
6. As of latest iteration, only a few milliseconds slower than previous version.

Fixes #864 