### PR TITLE
Pytests, fix error at teardown of TestGreenSocket.test_full_duplex

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -152,7 +152,7 @@ class LimitedTestCase(unittest.TestCase):
     timeout is 1 second, change it by setting TEST_TIMEOUT to the desired
     quantity."""
 
-    TEST_TIMEOUT = 1
+    TEST_TIMEOUT = 2
 
     def setUp(self):
         self.previous_alarm = None


### PR DESCRIPTION
Pytests keeps failing with below error:
 ERROR at teardown of TestGreenSocket.test_full_duplex
 tests/__init__.py:194: in tearDown

and above is caused by:
 eventlet/hubs/hub.py:310: TestIsTakingTooLong

By simply increasing the TEST_TIMEOUT let fully pass all the tests.