### PR TITLE
Fix deprecation warning on ssl.PROTOCOL_TLS

### DIFF
--- a/eventlet/green/ssl.py
+++ b/eventlet/green/ssl.py
@@ -55,7 +55,7 @@ class GreenSSLSocket(_original_sslsocket):
     """
     def __new__(cls, sock=None, keyfile=None, certfile=None,
                 server_side=False, cert_reqs=CERT_NONE,
-                ssl_version=PROTOCOL_SSLv23, ca_certs=None,
+                ssl_version=PROTOCOL_TLS, ca_certs=None,
                 do_handshake_on_connect=True, *args, **kw):
         if not isinstance(sock, GreenSocket):
             sock = GreenSocket(sock)
@@ -115,7 +115,7 @@ class GreenSSLSocket(_original_sslsocket):
     # do_handshake whose behavior we wish to override
     def __init__(self, sock, keyfile=None, certfile=None,
                  server_side=False, cert_reqs=CERT_NONE,
-                 ssl_version=PROTOCOL_SSLv23, ca_certs=None,
+                 ssl_version=PROTOCOL_TLS, ca_certs=None,
                  do_handshake_on_connect=True, *args, **kw):
         if not isinstance(sock, GreenSocket):
             sock = GreenSocket(sock)
@@ -437,7 +437,7 @@ if hasattr(__ssl, 'sslwrap_simple'):
         ssl_sock = GreenSSLSocket(sock, keyfile=keyfile, certfile=certfile,
                                   server_side=False,
                                   cert_reqs=CERT_NONE,
-                                  ssl_version=PROTOCOL_SSLv23,
+                                  ssl_version=PROTOCOL_TLS,
                                   ca_certs=None)
         return ssl_sock
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -152,7 +152,7 @@ class LimitedTestCase(unittest.TestCase):
     timeout is 1 second, change it by setting TEST_TIMEOUT to the desired
     quantity."""
 
-    TEST_TIMEOUT = 1
+    TEST_TIMEOUT = 2
 
     def setUp(self):
         self.previous_alarm = None

--- a/tests/ssl_test.py
+++ b/tests/ssl_test.py
@@ -328,7 +328,7 @@ class SSLTest(tests.LimitedTestCase):
                 listener.close()
 
     def test_context_wrapped_accept(self):
-        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         context.load_cert_chain(tests.certificate_file, tests.private_key_file)
         expected = "success:{}".format(random.random()).encode()
 


### PR DESCRIPTION
Fix deprecation warning on ssl.PROTOCOL_TLS

ssl.PROTOCOL_SSLv23 has been deprecated since version Python 3.6.
Use PROTOCOL_TLS instead.