### PR TITLE
Fix bad exceptions handlings

### DIFF
--- a/eventlet/green/os.py
+++ b/eventlet/green/os.py
@@ -41,12 +41,10 @@ def read(fd, n):
         try:
             return __original_read__(fd, n)
         except OSError as e:
-            if get_errno(e) != errno.EAGAIN:
-                raise
-        except OSError as e:
             if get_errno(e) == errno.EPIPE:
                 return ''
-            raise
+            if get_errno(e) != errno.EAGAIN:
+                raise
         try:
             hubs.trampoline(fd, read=True)
         except hubs.IOClosed:
@@ -65,10 +63,7 @@ def write(fd, st):
         try:
             return __original_write__(fd, st)
         except OSError as e:
-            if get_errno(e) != errno.EAGAIN:
-                raise
-        except OSError as e:
-            if get_errno(e) != errno.EPIPE:
+            if get_errno(e) not in [errno.EAGAIN, errno.EPIPE]:
                 raise
         hubs.trampoline(fd, write=True)
 


### PR DESCRIPTION
This patch fix 2 conditions that are badly designed. They can't work. In all case the exception will
be catched by the first `except` and then the second one will be all the time ignored.

Here is a tiny PoC to demonstrate the bad design:

```python
import errno

def trigger(err, message):
    print(f"try to simulate {message}: {err}")
    raise OSError(err, message)


def catcher(err, message):
    try:
        trigger(err, message)
    except OSError as e:
        print("I'm here")
        if e.errno != errno.EAGAIN:
            raise
    except OSError as e:
        print("I'm there")
        if e.errno == errno.EPIPE:
            return ''
        raise


if __name__ == "__main__":
    try:
        catcher(errno.EPIPE, "pipe!")
    except Exception as e:
        print(e)
    try:
        catcher(errno.EAGAIN, "again!")
    except Exception as e:
        print(e)
```

The previous code will output:

```
try to simulate pipe!: 32                                                      
I'm here                                                                       
[Errno 32] pipe!                                                                                                                                               
try to simulate again!: 11     
I'm here   
```