### PR TITLE
Handle transport endpoint shutdown in conditions

### DIFF
--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -36,7 +36,7 @@ for _mod in ('wsaccel.utf8validator', 'autobahn.utf8validator'):
     else:
         break
 
-ACCEPTABLE_CLIENT_ERRORS = {errno.ECONNRESET, errno.EPIPE}
+ACCEPTABLE_CLIENT_ERRORS = {errno.ECONNRESET, errno.EPIPE, errno.ESHUTDOWN}
 DEFAULT_MAX_FRAME_LENGTH = 8 << 20
 
 __all__ = ["WebSocketWSGI", "WebSocket"]

--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -62,7 +62,7 @@ def addr_to_host_port(addr):
 # Collections of error codes to compare against.  Not all attributes are set
 # on errno module on all platforms, so some are literals :(
 BAD_SOCK = {errno.EBADF, 10053}
-BROKEN_SOCK = {errno.EPIPE, errno.ECONNRESET}
+BROKEN_SOCK = {errno.EPIPE, errno.ECONNRESET, errno.ESHUTDOWN}
 
 
 class ChunkReadError(ValueError):
@@ -887,10 +887,11 @@ try:
     import ssl
     ACCEPT_EXCEPTIONS = (socket.error, ssl.SSLError)
     ACCEPT_ERRNO = {errno.EPIPE, errno.EBADF, errno.ECONNRESET,
-                    ssl.SSL_ERROR_EOF, ssl.SSL_ERROR_SSL}
+                    errno.ESHUTDOWN, ssl.SSL_ERROR_EOF, ssl.SSL_ERROR_SSL}
 except ImportError:
     ACCEPT_EXCEPTIONS = (socket.error,)
-    ACCEPT_ERRNO = {errno.EPIPE, errno.EBADF, errno.ECONNRESET}
+    ACCEPT_ERRNO = {errno.EPIPE, errno.EBADF, errno.ECONNRESET,
+                    errno.ESHUTDOWN}
 
 
 def socket_repr(sock):


### PR DESCRIPTION
ESHUTDOWN errors types are raised when a socket cannot send after transport endpoint is shutdown [1].

BrokenPipeError correspond to errno EPIPE and ESHUTDOWN. BrokenPipeError are raised when trying to write on a pipe while the other end has been closed, or trying to write on a socket which has been shutdown for writing [2].

If we specificaly handle EPIPE [3] in our exception management we should also handle ESHUTDOWN in the same way. A BrokenPipeError.

This patch made the addition of the ESHUTDOWN each time EPIPE is specificaly handled.

[1] https://docs.python.org/fr/3/library/errno.html#errno.ESHUTDOWN
[2] https://docs.python.org/fr/3/library/exceptions.html#BrokenPipeError
[3] https://docs.python.org/fr/3/library/errno.html#errno.EPIPE