### PR TITLE
install eventlet at readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,3 +30,5 @@ sphinx:
 python:
     install:
     - requirements: doc/requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
Else the build fails due to an eventlet import in the doc config [1].

[1] https://github.com/eventlet/eventlet/blob/master/doc/source/conf.py#L59