### PR TITLE
Add Python 3.7 to pyproject classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
The support of this version of python has been reintroduced [1].
Updating classifiers accordingly.

https://github.com/eventlet/eventlet/commit/64410214d0856f989e3b7c5f0bbe256d2b191f2f