### PR TITLE
Do not allow failed patching to stop execution

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,11 @@
 Unreleased
 ==========
 
+0.35.1
+======
+
+* [fix] Do not allow failed patching to stop execution https://github.com/eventlet/eventlet/pull/907
+
 0.35.0
 ======
 

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -465,10 +465,20 @@ def _upgrade_instances(container, klass, upgrade, visited=None, old_to_new=None)
     except TypeError:
         pass
     else:
-        for k, v in list(container_vars.items()):
-            new = upgrade_or_traverse(v)
-            if new is not None:
-                setattr(container, k, new)
+        # If we get here, we're operating on an object that could
+        # be doing strange things. If anything bad happens, error and
+        # warn the eventlet user to monkey_patch earlier.
+        try:
+            for k, v in list(container_vars.items()):
+                new = upgrade_or_traverse(v)
+                if new is not None:
+                    setattr(container, k, new)
+        except:
+            import logging
+            logger = logging.Logger("eventlet")
+            logger.exception("An exception was thrown while monkey_patching for eventlet. "
+                             "to fix this error make sure you run eventlet.monkey_patch() "
+                             "before importing any other modules.", exc_info=True)
 
 
 def _convert_py3_rlock(old, tid):

--- a/tests/isolated/patcher_existing_locks_exception.py
+++ b/tests/isolated/patcher_existing_locks_exception.py
@@ -1,0 +1,18 @@
+__test__ = False
+
+
+class BadDict(dict):
+    def items(self):
+        raise Exception()
+
+
+if __name__ == '__main__':
+    import threading
+    test_lock = threading.RLock()
+    test_lock.acquire()
+    baddict = BadDict(testkey='testvalue')
+
+    import eventlet
+    eventlet.monkey_patch()
+
+    print('pass')

--- a/tests/patcher_test.py
+++ b/tests/patcher_test.py
@@ -527,3 +527,7 @@ def test_open_kwargs():
 
 def test_patcher_existing_locks():
     tests.run_isolated("patcher_existing_locks_preexisting.py")
+
+
+def test_patcher_existing_locks_exception():
+    tests.run_isolated("patcher_existing_locks_exception.py")


### PR DESCRIPTION
There are some cases where monkey_patching cannot always be performed early enough; such as sphinx autodoc importing. To help handle these cases, exceptions during patching are logged and execution is allowed to continue.

This fixed an issue in OpenStack Manila docs generation caused by an upgrade to eventlet 0.35.0.