### PR TITLE
wsgi: Handle Timeouts from applications

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -631,7 +631,7 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
                     write(b''.join(towrite))
                 if not headers_sent or (use_chunked[0] and just_written_size):
                     write(b'')
-            except Exception:
+            except (Exception, eventlet.Timeout):
                 self.close_connection = 1
                 tb = traceback.format_exc()
                 self.server.log.info(tb)


### PR DESCRIPTION
If you're using eventlet as a web server, it's not unlikely that you'll be using `eventlet.Timeout`s at some point in your application callable or the response iterator that's returned. Don't let that blow up the whole worker greenthread, but treat it like other exceptions.