### PR TITLE
Fix tool.setuptools/packages list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ Documentation = "https://eventlet.readthedocs.io/"
 [project.optional-dependencies]
 dev = ["black", "isort", "pip-tools", "build", "twine", "pre-commit", "commitizen"]
 
+[tool.setuptools]
+packages = ['eventlet']
+
 [options.packages.find]
 where = "evenetlet"
 exclude = ["tests*", "benchmarks", "examples"]


### PR DESCRIPTION
In distros, when building the package and attempting to install it, there may be a "debian" folder. This creates this issue:

error: Multiple top-level packages discovered in a flat-layout: ['debian', 'eventlet'].

which is fixed by this patch. Please merge it to make it easier for package maintainers.