### PR TITLE
Add debug convenience helpers - asyncio, threads

### DIFF
--- a/eventlet/debug.py
+++ b/eventlet/debug.py
@@ -10,7 +10,8 @@ import inspect
 __all__ = ['spew', 'unspew', 'format_hub_listeners', 'format_hub_timers',
            'hub_listener_stacks', 'hub_exceptions', 'tpool_exceptions',
            'hub_prevent_multiple_readers', 'hub_timer_stacks',
-           'hub_blocking_detection']
+           'hub_blocking_detection', 'format_asyncio_info',
+           'format_threads_info']
 
 _token_splitter = re.compile(r'\W+')
 
@@ -81,6 +82,31 @@ def format_hub_listeners():
     result.append('WRITERS:')
     for l in hub.get_writers():
         result.append(repr(l))
+    return os.linesep.join(result)
+
+
+def format_asyncio_info():
+    """ Returns a formatted string of the asyncio info.
+    This can be useful in determining what's going on in the asyncio event
+    loop system, especially when used in conjunction with the asyncio hub.
+    """
+    import asyncio
+    tasks = asyncio.all_tasks()
+    result = ['TASKS:']
+    result.append(repr(tasks))
+    result.append(f'EVENTLOOP: {asyncio.events.get_event_loop()}')
+    return os.linesep.join(result)
+
+
+def format_threads_info():
+    """ Returns a formatted string of the threads info.
+    This can be useful in determining what's going on with created threads,
+    especially when used in conjunction with greenlet
+    """
+    import threading
+    threads = threading._active
+    result = ['THREADS:']
+    result.append(repr(threads))
     return os.linesep.join(result)
 
 


### PR DESCRIPTION
This patch aims to add some convenience helpers to help during debug session related to asyncio and threading.

Those can be used in any running context.
As example, those helper could be used during pdb sessions like this:

```
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
PDB post_mortem (IO-capturing turned off)
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /home/dev/app/tests/asyncio_test.py(235)go()
-> async def go():
(Pdb) import eventlet
(Pdb) pp eventlet.debug.format_threads_info()
('THREADS:\n'
 '{139916325074752: <_MainThread(MainThread, started
 139916325074752)>}')
(Pdb) pp eventlet.debug.format_asyncio_info()
('TASKS:\n'
 "{<Task pending name='Task-1' coro=<Hub.run.<locals>.async_run()
 running at "
  '/home/dev/app/eventlet/hubs/asyncio.py:141>
  cb=[_run_until_complete_cb() at '
   '/usr/local/lib/python3.12/asyncio/base_events.py:181] created at '
    '/usr/local/lib/python3.12/asyncio/tasks.py:695>}\n'
     'EVENTLOOP: <_UnixSelectorEventLoop running=True closed=False
     debug=True>')
```

The previous examples pretty print both helpers outputs.