### PR TITLE
Refactor congruence checks based on assert at runtime

### DIFF
--- a/eventlet/green/select.py
+++ b/eventlet/green/select.py
@@ -36,7 +36,8 @@ def select(read_list, write_list, error_list, timeout=None):
     hub = get_hub()
     timers = []
     current = eventlet.getcurrent()
-    assert hub.greenlet is not current, 'do not call blocking functions from the mainloop'
+    if hub.greenlet is current:
+        raise RuntimeError('do not call blocking functions from the mainloop')
     ds = {}
     for r in read_list:
         ds[get_fileno(r)] = {'read': r}

--- a/eventlet/greenthread.py
+++ b/eventlet/greenthread.py
@@ -31,7 +31,8 @@ def sleep(seconds=0):
     """
     hub = hubs.get_hub()
     current = getcurrent()
-    assert hub.greenlet is not current, 'do not call blocking functions from the mainloop'
+    if hub.greenlet is current:
+        raise RuntimeError('do not call blocking functions from the mainloop')
     timer = hub.schedule_call_global(seconds, current.switch)
     try:
         hub.switch()

--- a/eventlet/hubs/__init__.py
+++ b/eventlet/hubs/__init__.py
@@ -71,7 +71,8 @@ def use_hub(mod=None):
 
     classname = ''
     if isinstance(mod, str):
-        assert mod.strip(), "Need to specify a hub"
+        if mod.strip() == "":
+            raise RuntimeError("Need to specify a hub")
         if '.' in mod or ':' in mod:
             modulename, _, classname = mod.strip().partition(':')
         else:
@@ -134,9 +135,10 @@ def trampoline(fd, read=None, write=None, timeout=None,
     t = None
     hub = get_hub()
     current = greenlet.getcurrent()
-    assert hub.greenlet is not current, 'do not call blocking functions from the mainloop'
-    assert not (
-        read and write), 'not allowed to trampoline for reading and writing'
+    if hub.greenlet is current:
+        raise RuntimeError('do not call blocking functions from the mainloop')
+    if (read and write):
+        raise RuntimeError('not allowed to trampoline for reading and writing')
     try:
         fileno = fd.fileno()
     except AttributeError:


### PR DESCRIPTION
`assert` statements are completely eliminated when the python interpreter is ran with the optimization flags [1].

Those checks are not an option and should be executed not matter the execution context.

This patch refactor those checks to not rely anymore on the assert statement.

This patch is mainly focused on hub checks. Other assert statements are still present, I'll refactor them later.

Refactoring this kind of code ensure to not waste time managing issues and debugging bugs related to the optimization features of the interpreter.

[1] https://docs.python.org/3/using/cmdline.html#cmdoption-O