### PR TITLE
[doc] clean remnant refs to the pyevent removed hub

### DIFF
--- a/doc/source/reference/api/eventlet.hubs.rst
+++ b/doc/source/reference/api/eventlet.hubs.rst
@@ -44,14 +44,6 @@ eventlet.hubs.poll module
    :undoc-members:
    :show-inheritance:
 
-eventlet.hubs.pyevent module
-----------------------------
-
-.. automodule:: eventlet.hubs.pyevent
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 eventlet.hubs.selects module
 ----------------------------
 


### PR DESCRIPTION
The pyevent hub was removed one year ago, however the doc still contains a reference to it. This reference is empty and can let think that this hub is still present.

Lets remove this reference.