### PR TITLE
[DNM][deprecation] deprecate non asyncio hubs

### DIFF
--- a/doc/source/hubs.rst
+++ b/doc/source/hubs.rst
@@ -12,15 +12,16 @@ Eventlet has multiple hub implementations, and when you start using it, it tries
     | By using this hub, Asyncio and Eventlet can be run the same thread in the same process.
     | We discourage new Eventlet projects.
     | We encourage existing Eventlet projects to migrate from Eventlet to Asyncio.
+    | We encourage using this hub at runtime.
     | This hub allow you incremental and smooth migration.
     | See the `migration guide <https://eventlet.readthedocs.io/en/latest/migration.html>`_ for further details.
-**epolls**
+**(DEPRECATED) epolls**
     Linux. This is the fastest hub for Linux.
-**kqueue**
+**(DEPRECATED) kqueue**
     FreeBSD and Mac OSX. Fastest hub for OS with kqueue.
-**poll**
+**(DEPRECATED) poll**
     On platforms that support it.
-**selects**
+**(DEPRECATED) selects**
     Lowest-common-denominator, available everywhere.
 
 The only non-pure Python, pyevent hub (using libevent) was removed because it was not maintained. You are warmly welcome to contribute fast hub implementation using Cython, CFFI or other technology of your choice.

--- a/eventlet/hubs/epolls.py
+++ b/eventlet/hubs/epolls.py
@@ -1,4 +1,6 @@
 import errno
+import warnings
+
 from eventlet import patcher, support
 from eventlet.hubs import hub, poll
 select = patcher.original('select')
@@ -11,9 +13,28 @@ def is_available():
 # NOTE: we rely on the fact that the epoll flag constants
 # are identical in value to the poll constants
 class Hub(poll.Hub):
+    """
+    .. warning::
+        The eventlet epolls hub is now deprecated and will be removed.
+        Users should begin planning a migration from eventlet to asyncio.
+        Users are encouraged to switch to the eventlet asyncio hub in
+        order to start this migration.
+        Please find more details at https://eventlet.readthedocs.io/en/latest/migration.html
+    """
     def __init__(self, clock=None):
         super().__init__(clock=clock)
         self.poll = select.epoll()
+
+        warnings.warn(
+            """
+            ACTION REQUIRED: The eventlet epolls hub is now deprecated and will be removed.
+            Users should begin planning a migration from eventlet to asyncio.
+            Users are encouraged to switch to the eventlet asyncio hub in
+            order to start this migration.
+            Please find more details at https://eventlet.readthedocs.io/en/latest/migration.html
+            """,
+            DeprecationWarning,
+        )
 
     def add(self, evtype, fileno, cb, tb, mac):
         oldlisteners = bool(self.listeners[self.READ].get(fileno) or

--- a/eventlet/hubs/kqueue.py
+++ b/eventlet/hubs/kqueue.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import warnings
+
 from eventlet import patcher, support
 from eventlet.hubs import hub
 select = patcher.original('select')
@@ -11,6 +13,14 @@ def is_available():
 
 
 class Hub(hub.BaseHub):
+    """
+    .. warning::
+        The eventlet kqueue hub is now deprecated and will be removed.
+        Users should begin planning a migration from eventlet to asyncio.
+        Users are encouraged to switch to the eventlet asyncio hub in
+        order to start this migration.
+        Please find more details at https://eventlet.readthedocs.io/en/latest/migration.html
+    """
     MAX_EVENTS = 100
 
     def __init__(self, clock=None):
@@ -21,6 +31,17 @@ class Hub(hub.BaseHub):
         super().__init__(clock)
         self._events = {}
         self._init_kqueue()
+
+        warnings.warn(
+            """
+            ACTION REQUIRED: The eventlet kqueue hub is now deprecated and will be removed.
+            Users should begin planning a migration from eventlet to asyncio.
+            Users are encouraged to switch to the eventlet asyncio hub in
+            order to start this migration.
+            Please find more details at https://eventlet.readthedocs.io/en/latest/migration.html
+            """,
+            DeprecationWarning,
+        )
 
     def _init_kqueue(self):
         self.kqueue = select.kqueue()

--- a/eventlet/hubs/poll.py
+++ b/eventlet/hubs/poll.py
@@ -1,5 +1,6 @@
 import errno
 import sys
+import warnings
 
 from eventlet import patcher, support
 from eventlet.hubs import hub
@@ -12,12 +13,31 @@ def is_available():
 
 
 class Hub(hub.BaseHub):
+    """
+    .. warning::
+        The eventlet poll hub is now deprecated and will be removed.
+        Users should begin planning a migration from eventlet to asyncio.
+        Users are encouraged to switch to the eventlet asyncio hub in
+        order to start this migration.
+        Please find more details at https://eventlet.readthedocs.io/en/latest/migration.html
+    """
     def __init__(self, clock=None):
         super().__init__(clock)
         self.EXC_MASK = select.POLLERR | select.POLLHUP
         self.READ_MASK = select.POLLIN | select.POLLPRI
         self.WRITE_MASK = select.POLLOUT
         self.poll = select.poll()
+
+        warnings.warn(
+            """
+            ACTION REQUIRED: The eventlet poll hub is now deprecated and will be removed.
+            Users should begin planning a migration from eventlet to asyncio.
+            Users are encouraged to switch to the eventlet asyncio hub in
+            order to start this migration.
+            Please find more details at https://eventlet.readthedocs.io/en/latest/migration.html
+            """,
+            DeprecationWarning,
+        )
 
     def add(self, evtype, fileno, cb, tb, mac):
         listener = super().add(evtype, fileno, cb, tb, mac)

--- a/eventlet/hubs/selects.py
+++ b/eventlet/hubs/selects.py
@@ -1,5 +1,7 @@
 import errno
 import sys
+import warnings
+
 from eventlet import patcher, support
 from eventlet.hubs import hub
 select = patcher.original('select')
@@ -16,6 +18,28 @@ def is_available():
 
 
 class Hub(hub.BaseHub):
+    """
+    .. warning::
+        The eventlet selects hub is now deprecated and will be removed.
+        Users should begin planning a migration from eventlet to asyncio.
+        Users are encouraged to switch to the eventlet asyncio hub in
+        order to start this migration.
+        Please find more details at https://eventlet.readthedocs.io/en/latest/migration.html
+    """
+    def __init__(self, clock=None):
+        super().__init__(clock=clock)
+
+        warnings.warn(
+            """
+            ACTION REQUIRED: The eventlet selects hub is now deprecated and will be removed.
+            Users should begin planning a migration from eventlet to asyncio.
+            Users are encouraged to switch to the eventlet asyncio hub in
+            order to start this migration.
+            Please find more details at https://eventlet.readthedocs.io/en/latest/migration.html
+            """,
+            DeprecationWarning,
+        )
+
     def _remove_bad_fds(self):
         """ Iterate through fds, removing the ones that are bad per the
         operating system.


### PR DESCRIPTION
In accordance with our recent maintenance goals we sets [1][2] and in accordance with the recent addition of the asyncio hub [3], this patch proposes to deprecate all the other existing hubs, the non asyncio hubs, to encourage users to start their migration to asyncio.

[1] https://github.com/eventlet/eventlet/issues/835
[2] https://github.com/eventlet/eventlet/issues/824
[3] https://github.com/eventlet/eventlet/issues/868