### PR TITLE
eventlet.websocket is not always used from eventlet.wsgi, so do not assume `eventlet.set_idle` exists

### DIFF
--- a/eventlet/websocket.py
+++ b/eventlet/websocket.py
@@ -132,10 +132,11 @@ class WebSocketWSGI:
                            [('Connection', 'close'), ] + headers)
             return [body]
 
-        # We're ready to switch protocols; flag the connection
-        # as idle to play well with a graceful stop
-        environ['eventlet.set_idle']()
-
+        # We're ready to switch protocols; if running under Eventlet
+        # (this is not always the case) then flag the connection as
+        # idle to play well with a graceful stop
+        if 'eventlet.set_idle' in environ:
+            environ['eventlet.set_idle']()
         try:
             self.handler(ws)
         except OSError as e:


### PR DESCRIPTION
In the case where Eventlet's WebSocket implementation is used, for instance, in a Gunicorn worker, it ends up being the case that `WebSocketWSGI` is not running under an Eventlet server, and thus shouldn't assume that the environment contains `eventlet.set_idle` (which is an implementation detail of the Eventlet server and thus quite meaniningless).

This is notably the case when using Flask-SocketIO with Gunicorn as suggested in the documentation: https://flask-socketio.readthedocs.io/en/latest/deployment.html#gunicorn-web-server

It seems quite safe to just avoid trying to call it in this case.  If, for instance, the engineio wrapper (https://github.com/miguelgrinberg/python-engineio/blob/main/src/engineio/async_drivers/eventlet.py#L39) wishes to provide `eventlet.set_idle` for some reason, then it could do so.

Fixes #946 