### PR TITLE
ubuntu-22.04 fix: NoneType object has no attribute getcurrent()

### DIFF
--- a/eventlet/green/thread.py
+++ b/eventlet/green/thread.py
@@ -32,9 +32,12 @@ def _count():
 
 
 def get_ident(gr=None):
-    if gr is None:
-        return id(greenlet.getcurrent())
-    else:
+    try:
+        if gr is None:
+            return id(greenlet.getcurrent())
+        else:
+            return id(gr)
+    except:
         return id(gr)
 
 


### PR DESCRIPTION
related issue: https://github.com/eventlet/eventlet/issues/953