### PR TITLE
doc: Repair changelog link

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -113,7 +113,7 @@ Changelog
 =========
 
 For further details about released versions of Eventlet please take a
-look at the :ref:`changelog`.
+look at the `changelog`_.
 
 Authors & History
 =================
@@ -130,4 +130,7 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-* :ref:`changelog`
+* `changelog`_
+
+
+.. _changelog: https://github.com/eventlet/eventlet/blob/master/NEWS


### PR DESCRIPTION
Currently, the link to the changelog found in the Eventlet docs at https://eventlet.readthedocs.io/en/latest/index.html#changelog links to the *Python* changelog, at https://docs.python.org/3/whatsnew/changelog.html#changelog.

This PR changes it to point to https://github.com/eventlet/eventlet/blob/master/NEWS

### Other possibilities

I noticed there's a reference to a `changelog.html` here:

https://github.com/eventlet/eventlet/blob/c22b896473fc38864a3ace488ddc4b0514177cae/doc/source/real_index.html#L151

so maybe there was some intention to generate a true changelog page, belonging to the docs? Don't know.
