### PR TITLE
drop header keys with underscores

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -748,6 +748,9 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
 
         env['headers_raw'] = headers_raw = tuple((k, v.strip(' \t\n\r')) for k, v in headers)
         for k, v in headers_raw:
+            if "_" in k:
+                continue
+
             k = k.replace('-', '_').upper()
             if k in ('CONTENT_TYPE', 'CONTENT_LENGTH'):
                 # These do not get the HTTP_ prefix and were handled above

--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -706,6 +706,23 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
                 host = forward + ',' + host
         return (host, port)
 
+    def formalize_key_naming(self, k):
+        """
+        Headers containing underscores are permitted by RFC9110,
+        but evenlet joining headers of different names into
+        the same environment variable will dangerously confuse applications as to which is which.
+        Cf.
+            - Nginx: http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers
+            - Django: https://www.djangoproject.com/weblog/2015/jan/13/security/
+            - Gunicorn: https://github.com/benoitc/gunicorn/commit/72b8970dbf2bf3444eb2e8b12aeff1a3d5922a9a
+            - Werkzeug: https://github.com/pallets/werkzeug/commit/5ee439a692dc4474e0311de2496b567eed2d02cf
+            - ...
+        """
+        if "_" in k:
+            return
+
+        return k.replace('-', '_').upper()
+
     def get_environ(self):
         env = self.server.get_environ()
         env['REQUEST_METHOD'] = self.command
@@ -748,10 +765,10 @@ class HttpProtocol(BaseHTTPServer.BaseHTTPRequestHandler):
 
         env['headers_raw'] = headers_raw = tuple((k, v.strip(' \t\n\r')) for k, v in headers)
         for k, v in headers_raw:
-            if "_" in k:
+            k = self.formalize_key_naming(k)
+            if not k:
                 continue
 
-            k = k.replace('-', '_').upper()
             if k in ('CONTENT_TYPE', 'CONTENT_LENGTH'):
                 # These do not get the HTTP_ prefix and were handled above
                 continue

--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -1924,8 +1924,8 @@ class TestHttpd(_TestBase):
         result = read_http(sock)
         sock.close()
         assert result.status == 'HTTP/1.1 200 OK', 'Received status {!r}'.format(result.status)
-        assert result.body == (b'HTTP_HOST: localhost\nHTTP_HTTP_X_ANY_K: two\n'
-                               b'HTTP_PATH_INFO: foo\nHTTP_X_ANY_K: one\n')
+        assert result.body == (b'HTTP_HOST: localhost\n'
+                               b'HTTP_PATH_INFO: foo\n')
 
     def test_env_header_stripping(self):
         def app(environ, start_response):


### PR DESCRIPTION
Headers which contain `_` shouldn't be allowed as they could create confusion in incoming requests, allowing, for example, the usage of `CONTENT_LENGTH` instead of `Content-Length`.

This has already been fixed in various WSGI/proxy servers:

- [Nginx](http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers)
- [Django](https://www.djangoproject.com/weblog/2015/jan/13/security/)
- [Gunicorn](https://github.com/benoitc/gunicorn/commit/72b8970dbf2bf3444eb2e8b12aeff1a3d5922a9a)
- [Werkzeug](https://github.com/pallets/werkzeug/commit/5ee439a692dc4474e0311de2496b567eed2d02cf)
- ...
