### PR TITLE
Upgrade RLocks as last thing we do

### DIFF
--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -433,6 +433,7 @@ def _green_existing_locks(rlock_type):
                      " to fix this error make sure you run eventlet.monkey_patch() " +
                      "before importing any other modules.")
 
+
 def _upgrade_instances(container, klass, upgrade, visited=None, old_to_new=None):
     """
     Starting with a Python object, find all instances of ``klass``, following


### PR DESCRIPTION
Fixes #969 

Also hide an upgradable RLock in some edge cases.

I tried writing a test but completely failed at getting it to reproduce when run via pytest (it always passes regardless), even though it does reproduce when run manually :cry: So I didn't check it in.
