### PR TITLE
os.read/write waits until file descriptor is ready.

### DIFF
--- a/tests/isolated/os_read_nonblocking.py
+++ b/tests/isolated/os_read_nonblocking.py
@@ -1,0 +1,30 @@
+if __name__ == '__main__':
+    import eventlet
+    from eventlet.greenthread import sleep, spawn
+
+    eventlet.monkey_patch()
+
+    import signal
+    import os
+
+    thread = None
+    timed_out = False
+
+    def on_timeout(signum, frame):
+        global timed_out
+        timed_out = True
+        thread.kill()
+
+    def blocking_read(fd):
+        os.read(fd, 4096)
+
+    signal.signal(signal.SIGALRM, on_timeout)
+    signal.alarm(3)
+
+    read_fd, write_fd = os.pipe()
+    thread = spawn(blocking_read, read_fd)
+    sleep(0)
+
+    assert not timed_out
+
+    print('pass')

--- a/tests/isolated/os_write_nonblocking.py
+++ b/tests/isolated/os_write_nonblocking.py
@@ -1,0 +1,35 @@
+if __name__ == '__main__':
+    import eventlet
+    from eventlet.greenthread import sleep, spawn
+
+    eventlet.monkey_patch()
+
+    import signal
+    import os
+
+    thread = None
+    timed_out = False
+
+    def on_timeout(signum, frame):
+        global timed_out
+        timed_out = True
+        thread.kill()
+
+    def blocking_write(fd):
+        # once the write buffer is filled up, it should go to sleep instead of blocking
+        # write 1 byte at a time as writing large data will block
+        # even if select/poll claims otherwise
+        for i in range(1, 1000000):
+            os.write(fd, b'\0')
+
+    signal.signal(signal.SIGALRM, on_timeout)
+    signal.alarm(5)
+
+    read_fd, write_fd = os.pipe()
+    thread = spawn(blocking_write, write_fd)
+    # 2 secs is enough time for write buffer to fill up
+    sleep(2)
+
+    assert not timed_out
+
+    print('pass')

--- a/tests/os_test.py
+++ b/tests/os_test.py
@@ -12,3 +12,7 @@ def test_pathlib_open_issue_534():
 
 def test_os_read_nonblocking():
     tests.run_isolated('os_read_nonblocking.py')
+
+
+def test_os_write_nonblocking():
+    tests.run_isolated('os_write_nonblocking.py')

--- a/tests/os_test.py
+++ b/tests/os_test.py
@@ -1,4 +1,5 @@
 import eventlet
+import tests
 
 
 def test_pathlib_open_issue_534():
@@ -7,3 +8,7 @@ def test_pathlib_open_issue_534():
     with path.open():
         # should not raise
         pass
+
+
+def test_os_read_nonblocking():
+    tests.run_isolated('os_read_nonblocking.py')


### PR DESCRIPTION
Fixes #973 
Fixes #634 

Currently, calling `os.read(fd, size)` will attempt to read the file descriptor immediately. If there is no data to be read, the thread will block until data is available, causing the program to hang. With this pull request, `os.read` will wait until the file descriptor is ready to read before attempting a read. It will not wait if the file descriptor is a regular file (according to select/poll, regular files are always ready to read).

My fear is that `os.write` has the same bug:
https://github.com/eventlet/eventlet/blob/06ec82896ebb9a26edaf6e1ad4d63393990f15b7/eventlet/green/os.py#L57-L68

It's not common for a write call to block, but it can happen, and if it does happen, the entire program will hang. Do you want me to investigate and fix this as well?