### PR TITLE
wsgi: No request Content-Length nor Transfer-Encoding implies no body

### DIFF
--- a/tests/wsgi_test.py
+++ b/tests/wsgi_test.py
@@ -2138,6 +2138,32 @@ class TestHttpd(_TestBase):
         assert result.status == 'HTTP/1.1 200 OK', 'Received status {!r}'.format(result.status)
         sock.close()
 
+    def test_no_content_length_or_transfer_encoding(self):
+        def wsgi_app(environ, start_response):
+            start_response('200 OK', [])
+            return [environ['wsgi.input'].read(1024)]
+
+        self.site.application = wsgi_app
+        sock = eventlet.connect(self.server_addr)
+        sock.send(
+            b'GET / HTTP/1.1\r\n'
+            b'Host: localhost\r\n'
+            b'\r\n')
+        result = read_http(sock)
+        assert result.status == 'HTTP/1.1 200 OK', 'Received status {!r}'.format(result.status)
+        assert result.body == b''
+        # socket's still good
+        sock.send(
+            b'GET / HTTP/1.1\r\n'
+            b'Content-Length: 6\r\n'
+            b'Host: localhost\r\n'
+            b'\r\n'
+            b'hello\n')
+        result = read_http(sock)
+        assert result.status == 'HTTP/1.1 200 OK', 'Received status {!r}'.format(result.status)
+        assert result.body == b'hello\n'
+        sock.close()
+
 
 def read_headers(sock):
     fd = sock.makefile('rb')


### PR DESCRIPTION
Previously, if an application tried to read some set length from such a request (because, say, it always tried to read every request's body), the server could hang waiting on the client to send more bytes.

The spec, however, is clear -- even going back to HTTP/1.0 -- if `Content-Length` (nor `Transfer-Encoding`, in HTTP/1.1) is missing, the request has no body, which is equivalent to having a body of length 0.