### PR TITLE
Python 3.13 Support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,8 @@ jobs:
           - { py: "3.11", toxenv: py311-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-epolls, ignore-error: false, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: ubuntu-latest }
+          - { py: "3.13", toxenv: py313-epolls, ignore-error: false, os:ubuntu-24.04 }
+          - { py: "3.13", toxenv: py313-asyncio, ignore-error: false, os:ubuntu-24.04 }
           - { py: pypy3.9, toxenv: pypy3-epolls, ignore-error: true, os: ubuntu-20.04 }
 
     steps:
@@ -98,6 +100,7 @@ jobs:
       matrix:
         include:
           - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: macos-latest }
+          - { py: "3.13", toxenv: py313-asyncio, ignore-error: false, os: macos-latest }
           # This isn't working very well at the moment, but that might just be
           # tox config? In any case main focus is on asyncio so someone can
           # revisit separately.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,8 +50,8 @@ jobs:
           - { py: "3.11", toxenv: py311-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-epolls, ignore-error: false, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.13.0-beta.2", toxenv: py313-epolls, ignore-error: false, os: ubuntu-24.04 }
-          - { py: "3.13.0-beta.2", toxenv: py313-asyncio, ignore-error: false, os: ubuntu-24.04 }
+          - { py: "3.13-dev", toxenv: py313-epolls, ignore-error: false, os: ubuntu-24.04 }
+          - { py: "3.13-dev", toxenv: py313-asyncio, ignore-error: false, os: ubuntu-24.04 }
           - { py: pypy3.9, toxenv: pypy3-epolls, ignore-error: true, os: ubuntu-20.04 }
 
     steps:
@@ -100,7 +100,7 @@ jobs:
       matrix:
         include:
           - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: macos-latest }
-          - { py: "3.13.0-beta.2", toxenv: py313-asyncio, ignore-error: false, os: macos-latest }
+          - { py: "3.13-dev", toxenv: py313-asyncio, ignore-error: false, os: macos-latest }
           # This isn't working very well at the moment, but that might just be
           # tox config? In any case main focus is on asyncio so someone can
           # revisit separately.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,25 +30,25 @@ jobs:
       matrix:
         include:
           - { py: 3.7, toxenv: py37-epolls, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.7, toxenv: py37-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: 3.8, toxenv: py38-epolls, ignore-error: false, os: ubuntu-latest }
           - { py: 3.8, toxenv: py38-openssl, ignore-error: false, os: ubuntu-latest }
           - { py: 3.8, toxenv: py38-poll, ignore-error: false, os: ubuntu-latest }
           - { py: 3.8, toxenv: py38-selects, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.8, toxenv: py38-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: 3.9, toxenv: py39-epolls, ignore-error: false, os: ubuntu-latest }
           - { py: 3.9, toxenv: py39-poll, ignore-error: false, os: ubuntu-latest }
           - { py: 3.9, toxenv: py39-selects, ignore-error: false, os: ubuntu-latest }
           - { py: 3.9, toxenv: py39-dnspython1, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.9, toxenv: py39-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: "3.10", toxenv: py310-epolls, ignore-error: false, os: ubuntu-latest }
           - { py: "3.10", toxenv: py310-poll, ignore-error: false, os: ubuntu-latest }
           - { py: "3.10", toxenv: py310-selects, ignore-error: false, os: ubuntu-latest }
           - { py: "3.10", toxenv: ipv6, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.11", toxenv: py311-epolls, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.12", toxenv: py312-epolls, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.7", toxenv: py37-asyncio, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.8", toxenv: py38-asyncio, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.9", toxenv: py39-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: "3.10", toxenv: py310-asyncio, ignore-error: false, os: ubuntu-latest }
+          - { py: "3.11", toxenv: py311-epolls, ignore-error: false, os: ubuntu-latest }
           - { py: "3.11", toxenv: py311-asyncio, ignore-error: false, os: ubuntu-latest }
+          - { py: "3.12", toxenv: py312-epolls, ignore-error: false, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: pypy3.9, toxenv: pypy3-epolls, ignore-error: true, os: ubuntu-20.04 }
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,8 +50,8 @@ jobs:
           - { py: "3.11", toxenv: py311-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-epolls, ignore-error: false, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.13", toxenv: py313-epolls, ignore-error: false, os: ubuntu-24.04 }
-          - { py: "3.13", toxenv: py313-asyncio, ignore-error: false, os: ubuntu-24.04 }
+          - { py: "3.13.0-beta.2", toxenv: py313-epolls, ignore-error: false, os: ubuntu-24.04 }
+          - { py: " 3.13.0-beta.2", toxenv: py313-asyncio, ignore-error: false, os: ubuntu-24.04 }
           - { py: pypy3.9, toxenv: pypy3-epolls, ignore-error: true, os: ubuntu-20.04 }
 
     steps:
@@ -100,7 +100,7 @@ jobs:
       matrix:
         include:
           - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: macos-latest }
-          - { py: "3.13", toxenv: py313-asyncio, ignore-error: false, os: macos-latest }
+          - { py: "3.13.0-beta.2", toxenv: py313-asyncio, ignore-error: false, os: macos-latest }
           # This isn't working very well at the moment, but that might just be
           # tox config? In any case main focus is on asyncio so someone can
           # revisit separately.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,8 +50,8 @@ jobs:
           - { py: "3.11", toxenv: py311-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-epolls, ignore-error: false, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.13", toxenv: py313-epolls, ignore-error: false, os:ubuntu-24.04 }
-          - { py: "3.13", toxenv: py313-asyncio, ignore-error: false, os:ubuntu-24.04 }
+          - { py: "3.13", toxenv: py313-epolls, ignore-error: false, os: ubuntu-24.04 }
+          - { py: "3.13", toxenv: py313-asyncio, ignore-error: false, os: ubuntu-24.04 }
           - { py: pypy3.9, toxenv: pypy3-epolls, ignore-error: true, os: ubuntu-20.04 }
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
           - { py: "3.12", toxenv: py312-epolls, ignore-error: false, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: "3.13.0-beta.2", toxenv: py313-epolls, ignore-error: false, os: ubuntu-24.04 }
-          - { py: " 3.13.0-beta.2", toxenv: py313-asyncio, ignore-error: false, os: ubuntu-24.04 }
+          - { py: "3.13.0-beta.2", toxenv: py313-asyncio, ignore-error: false, os: ubuntu-24.04 }
           - { py: pypy3.9, toxenv: pypy3-epolls, ignore-error: true, os: ubuntu-20.04 }
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -85,4 +85,4 @@ The built html files can be found in doc/build/html afterward.
 Supported Python versions
 =========================
 
-Python 3.7-3.12 are currently supported.
+Python 3.7-3.13 are currently supported.

--- a/eventlet/green/thread.py
+++ b/eventlet/green/thread.py
@@ -80,10 +80,10 @@ def _make_thread_handle(ident):
 
 
 def __spawn_green(function, args=(), kwargs=None, joinable=False):
-    if (sys.version_info >= (3, 4)
+    if ((3, 4) <= sys.version_info < (3, 13)
             and getattr(function, '__module__', '') == 'threading'
             and hasattr(function, '__self__')):
-        # Since Python 3.4, threading.Thread uses an internal lock
+        # In Python 3.4-3.12, threading.Thread uses an internal lock
         # automatically released when the python thread state is deleted.
         # With monkey patching, eventlet uses green threads without python
         # thread state, so the lock is not automatically released.
@@ -98,7 +98,7 @@ def __spawn_green(function, args=(), kwargs=None, joinable=False):
                 bootstrap_inner()
             finally:
                 # The lock can be cleared (ex: by a fork())
-                if thread._tstate_lock is not None:
+                if getattr(thread, "_tstate_lock", None) is not None:
                     thread._tstate_lock.release()
 
         thread._bootstrap_inner = wrap_bootstrap_inner

--- a/eventlet/green/threading.py
+++ b/eventlet/green/threading.py
@@ -4,9 +4,10 @@ from eventlet.green import thread
 from eventlet.green import time
 from eventlet.support import greenlets as greenlet
 
-__patched__ = ['_start_new_thread', '_allocate_lock',
-               '_sleep', 'local', 'stack_size', 'Lock', 'currentThread',
-               'current_thread', '_after_fork', '_shutdown']
+__patched__ = ['Lock', '_after_fork', '_allocate_lock', '_get_main_thread_ident',
+               '_make_thread_handle', '_shutdown', '_sleep',
+               '_start_joinable_thread', '_start_new_thread', '_ThreadHandle',
+               'currentThread', 'current_thread', 'local', 'stack_size']
 
 __patched__ += ['get_ident', '_set_sentinel']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python",
     "Topic :: Internet",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist =
     py38-openssl
     py39-dnspython1
     pypy3-epolls
-    py{38,39,310,311,312}-{selects,poll,epolls,asyncio}
+    py{38,39,310,311,312,313}-{selects,poll,epolls,asyncio}
 skipsdist = True
 
 [testenv:ipv6]


### PR DESCRIPTION
Following on from #966, implement the Python 3.13 `start_joinable_thread` API using greenthreads.

We cut some corners, of course:
* We aren't maintaining a table of green thread idents to threads, so we can't wait for all threads on shutdown.
* Our `_make_thread_handle()` can only make a handle for the current thread (as we don't have a way to look up green threads by ident). This seems to be good enough.
* `.join()` on a non-GreenThread (e.g. the main thread) just returns immediately.