### PR TITLE
Correct line lookup from inspect.getsourcelines()

### DIFF
--- a/eventlet/debug.py
+++ b/eventlet/debug.py
@@ -35,8 +35,12 @@ class Spew:
             else:
                 name = '[unknown]'
                 try:
-                    src = inspect.getsourcelines(frame)
-                    line = src[lineno]
+                    src, offset = inspect.getsourcelines(frame)
+                    # The first line is line 1
+                    # But 0 may be returned when executing module-level code
+                    if offset == 0:
+                        offset = 1
+                    line = src[lineno - offset]
                 except OSError:
                     line = 'Unknown code named [%s].  VM instruction #%d' % (
                         frame.f_code.co_name, frame.f_lasti)

--- a/tests/debug_test.py
+++ b/tests/debug_test.py
@@ -1,4 +1,5 @@
 import io
+import os
 import sys
 
 from eventlet import debug
@@ -50,7 +51,8 @@ class TestSpew(tests.LimitedTestCase):
         s(f, "line", None)
         output = sys.stdout.getvalue()
         assert "[unknown]:%i" % lineno in output, "Didn't find [unknown]:%i in %s" % (lineno, output)
-        assert "VM instruction #" in output, output
+        if "PYTEST_XDIST_WORKER" not in os.environ:
+            assert "VM instruction #" in output, output
 
     def test_line_global(self):
         frame_str = "f=<frame at"


### PR DESCRIPTION
I can't write a test for this, as I don't know how to trigger this part of Spew, without also falling into the OSError branch (which `test_line_nofile` tests).

However, it has been observed to hit this code when running the tests under pytest-xdist (execnext), which pokes around in `linecache`, and the code is obviously wrong. This corrects it.