### PR TITLE
asyncio hub should error out if asyncio has already been imported

### DIFF
--- a/eventlet/hubs/asyncio.py
+++ b/eventlet/hubs/asyncio.py
@@ -33,7 +33,10 @@ class Hub(hub.BaseHub):
     def __init__(self):
         super().__init__()
 
-        if "asyncio.selector_events" in sys.modules:
+        # We do the socket.socket comparison to handle the fork() case where
+        # sys.modules is pre-monkeypatched...
+        if "asyncio.selector_events" in sys.modules and sys.modules[
+                "asyncio.selector_events"].socket.socket != original("socket").socket:
             raise RuntimeError(
                 "asyncio has already been imported before hub creation and "
                 "monkey patching. Try calling eventlet.monkey_patch() earlier. "

--- a/eventlet/hubs/asyncio.py
+++ b/eventlet/hubs/asyncio.py
@@ -33,6 +33,14 @@ class Hub(hub.BaseHub):
     def __init__(self):
         super().__init__()
 
+        if "asyncio.selector_events" in sys.modules:
+            raise RuntimeError(
+                "asyncio has already been imported before hub creation and "
+                "monkey patching. Try calling eventlet.monkey_patch() earlier. "
+                "If that is not possible, use the EVENTLET_MONKEYPATCH=1 env "
+                "variable instead of eventlet.monkey_patch()."
+            )
+
         # Make sure select/poll/epoll/kqueue are usable by asyncio, original
         # socket.socketpair is used by asyncio, real thread pools are used,
         # etc:

--- a/tests/asyncio_test.py
+++ b/tests/asyncio_test.py
@@ -1,26 +1,26 @@
 """Tests for asyncio integration."""
 
+import pytest
+
+import eventlet
+from eventlet.hubs import get_hub
+from eventlet.hubs.asyncio import Hub as AsyncioHub
+if not isinstance(get_hub(), AsyncioHub):
+    pytest.skip("Only works on asyncio hub", allow_module_level=True)
+
 import asyncio
 from time import time
 import socket
 import sys
 
-import pytest
-
 from greenlet import GreenletExit
 
-import eventlet
-from eventlet.hubs import get_hub
-from eventlet.hubs.asyncio import Hub as AsyncioHub
 from eventlet.asyncio import spawn_for_awaitable
 from eventlet.greenthread import getcurrent
 from eventlet.support import greendns
 from .wsgi_test import _TestBase, Site
 
 import tests
-
-if not isinstance(get_hub(), AsyncioHub):
-    pytest.skip("Only works on asyncio hub", allow_module_level=True)
 
 
 class CallingAsyncFunctionsFromGreenletsHighLevelTests(_TestBase):
@@ -298,9 +298,16 @@ def test_asyncio_to_thread():
     tests.run_isolated("asyncio_to_thread.py")
 
 
-def test_asyncio_does_not_use_greendns(monkeypatch):
+def test_asyncio_does_not_use_greendns():
     """
     ``asyncio`` loops' ``getaddrinfo()`` and ``getnameinfo()`` do not use green
     DNS.
     """
     tests.run_isolated("asyncio_dns.py")
+
+
+def test_error_if_asyncio_imported_before_hub_initialization():
+    """
+    ``asyncio`` hub complains if asyncio has been imported before it.
+    """
+    tests.run_isolated("asyncio_too_early.py")

--- a/tests/isolated/asyncio_dns.py
+++ b/tests/isolated/asyncio_dns.py
@@ -1,3 +1,6 @@
+import eventlet
+eventlet.monkey_patch()
+
 import asyncio
 import socket
 
@@ -12,9 +15,6 @@ def fail(*args, **kwargs):
 greendns.resolve = fail
 greendns.resolver.query = fail
 
-import eventlet
-
-eventlet.monkey_patch()
 
 
 async def lookups():

--- a/tests/isolated/asyncio_dns.py
+++ b/tests/isolated/asyncio_dns.py
@@ -16,7 +16,6 @@ greendns.resolve = fail
 greendns.resolver.query = fail
 
 
-
 async def lookups():
     loop = asyncio.get_running_loop()
     await loop.getaddrinfo("127.0.0.1", 80)

--- a/tests/isolated/asyncio_to_thread.py
+++ b/tests/isolated/asyncio_to_thread.py
@@ -1,8 +1,9 @@
 import eventlet
+eventlet.monkey_patch()
+
 from eventlet.patcher import original
 from eventlet.asyncio import spawn_for_awaitable
 
-eventlet.monkey_patch()
 import asyncio
 
 

--- a/tests/isolated/asyncio_too_early.py
+++ b/tests/isolated/asyncio_too_early.py
@@ -1,0 +1,10 @@
+import asyncio
+import eventlet
+try:
+    eventlet.monkey_patch()
+except RuntimeError as e:
+    assert "asyncio has already been imported" in str(e)
+else:
+    raise RuntimeError("No error raised, this is a bug")
+
+print("pass")

--- a/tests/isolated/patcher_existing_locks_preexisting.py
+++ b/tests/isolated/patcher_existing_locks_preexisting.py
@@ -31,6 +31,10 @@ if __name__ == '__main__':
     if sys.version_info[:2] > (3, 9):
         print(unittest.mock.NonCallableMock._lock)
     print(NS.lock)
+    # unittest.mock imports asyncio, so clear out asyncio.
+    for name in list(sys.modules.keys()):
+        if name.startswith("asyncio"):
+            del sys.modules[name]
     eventlet.monkey_patch()
     ensure_upgraded(NS.lock)
     ensure_upgraded(NS.NS2.lock)


### PR DESCRIPTION
Fixes #1003

Lacking this asyncio hub will start, but anti-monkeypatching may be only partial, in which case it triggers the errors in #994 again.