### PR TITLE
Remove monotonic from requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dynamic = ["version"]
 dependencies = [
     'dnspython >= 1.15.0',
     'greenlet >= 1.0',
-    'monotonic >= 1.4;python_version<"3.5"',
 ]
 
 [project.urls]


### PR DESCRIPTION
... because it is required only in Python <= 3.5 which has no overlap with the python versions currently supported.