### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,12 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { py: 3.8, toxenv: py38-epolls, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.8, toxenv: py38-openssl, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.8, toxenv: py38-poll, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.8, toxenv: py38-selects, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.8, toxenv: py38-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: 3.9, toxenv: py39-epolls, ignore-error: false, os: ubuntu-latest }
+          - { py: 3.9, toxenv: py39-openssl, ignore-error: false, os: ubuntu-latest }
           - { py: 3.9, toxenv: py39-poll, ignore-error: false, os: ubuntu-latest }
           - { py: 3.9, toxenv: py39-selects, ignore-error: false, os: ubuntu-latest }
           - { py: 3.9, toxenv: py39-dnspython1, ignore-error: false, os: ubuntu-latest }

--- a/README.rst
+++ b/README.rst
@@ -85,4 +85,4 @@ The built html files can be found in doc/build/html afterward.
 Supported Python versions
 =========================
 
-Python 3.8-3.13 are currently supported.
+Python 3.9-3.13 are currently supported.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -74,7 +74,7 @@ Code talks!  This is a simple web crawler that fetches a bunch of urls concurren
 Supported Python Versions
 =========================
 
-Currently supporting CPython 3.8+.
+Currently supporting CPython 3.9+.
 
 
 Concepts & References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 ]
 description = "Highly concurrent networking library"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "MIT"}
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -27,7 +27,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,10 @@ minversion=2.5
 envlist =
     ipv6
     pep8
-    py38-openssl
+    py39-openssl
     py39-dnspython1
     pypy3-epolls
-    py{38,39,310,311,312,313}-{selects,poll,epolls,asyncio}
+    py{39,310,311,312,313}-{selects,poll,epolls,asyncio}
 skipsdist = True
 
 [testenv:ipv6]
@@ -69,11 +69,11 @@ deps =
     coverage
     pytest
     pytest-cov
-    py38-openssl: pyopenssl==22.1.0
+    py39-openssl: pyopenssl==22.1.0
     pypy3: psycopg2cffi-compat==1.1
-    py{38,39}-{selects,poll,epolls}: pyzmq==21.0.2
-    py{38,39,310,311}: mysqlclient==2.0.3
-    py{38,39}: psycopg2-binary==2.8.4
+    py39-{selects,poll,epolls}: pyzmq==21.0.2
+    py{39,310,311}: mysqlclient==2.0.3
+    py39: psycopg2-binary==2.8.4
     py{310,311}: psycopg2-binary==2.9.5
     py{310,311}: pyzmq==25.0.0
     dnspython1: dnspython<2


### PR DESCRIPTION
Python 3.8 already reached its eol on 2024-10-07 .