### PR TITLE
Fix ssl test when linking against openssl 3.5+

### DIFF
--- a/tests/ssl_test.py
+++ b/tests/ssl_test.py
@@ -80,7 +80,8 @@ class SSLTest(tests.LimitedTestCase):
             sock.recv(8192)
             try:
                 self.assertEqual(b'', sock.recv(8192))
-            except greenio.SSL.ZeroReturnError:
+            except (greenio.SSL.ZeroReturnError,
+                    BrokenPipeError):
                 pass
 
         sock = listen_ssl_socket()


### PR DESCRIPTION
Openssl 3.5 changed some error propagations. As a result, sometimes instead of SSL_Error we get a Broken Pipe. Update the ssl_test to handle that.