### PR TITLE
make pypy jobs optional

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,9 +5,9 @@ on:
   schedule:
     - cron: "43 7 */14 * *" # every two weeks, time chosen by RNG
 jobs:
-  tox:
-    name: "tox ${{ matrix.toxenv }}"
-    continue-on-error: ${{ matrix.ignore-error }}
+  # Required tests
+  required-tests:
+    name: "Required Tests: ${{ matrix.toxenv }}"
     runs-on: ${{ matrix.os }}
     # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012/5
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'eventlet/eventlet'
@@ -29,28 +29,74 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { py: 3.8, toxenv: py38-epolls, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.8, toxenv: py38-openssl, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.8, toxenv: py38-poll, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.8, toxenv: py38-selects, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.8, toxenv: py38-asyncio, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.9, toxenv: py39-epolls, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.9, toxenv: py39-poll, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.9, toxenv: py39-selects, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.9, toxenv: py39-dnspython1, ignore-error: false, os: ubuntu-latest }
-          - { py: 3.9, toxenv: py39-asyncio, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.10", toxenv: py310-epolls, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.10", toxenv: py310-poll, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.10", toxenv: py310-selects, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.10", toxenv: ipv6, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.10", toxenv: py310-asyncio, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.11", toxenv: py311-epolls, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.11", toxenv: py311-asyncio, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.12", toxenv: py312-epolls, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: ubuntu-latest }
-          - { py: "3.13", toxenv: py313-epolls, ignore-error: false, os: ubuntu-24.04 }
-          - { py: "3.13", toxenv: py313-asyncio, ignore-error: false, os: ubuntu-24.04 }
-          - { py: pypy3.9, toxenv: pypy3-epolls, ignore-error: true, os: ubuntu-20.04 }
+          - { py: 3.8, toxenv: py38-epolls, os: ubuntu-latest }
+          - { py: 3.8, toxenv: py38-openssl, os: ubuntu-latest }
+          - { py: 3.8, toxenv: py38-poll, os: ubuntu-latest }
+          - { py: 3.8, toxenv: py38-selects, os: ubuntu-latest }
+          - { py: 3.8, toxenv: py38-asyncio, os: ubuntu-latest }
+          - { py: 3.9, toxenv: py39-epolls, os: ubuntu-latest }
+          - { py: 3.9, toxenv: py39-poll, os: ubuntu-latest }
+          - { py: 3.9, toxenv: py39-selects, os: ubuntu-latest }
+          - { py: 3.9, toxenv: py39-dnspython1, os: ubuntu-latest }
+          - { py: 3.9, toxenv: py39-asyncio, os: ubuntu-latest }
+          - { py: "3.10", toxenv: py310-epolls, os: ubuntu-latest }
+          - { py: "3.10", toxenv: py310-poll, os: ubuntu-latest }
+          - { py: "3.10", toxenv: py310-selects, os: ubuntu-latest }
+          - { py: "3.10", toxenv: ipv6, os: ubuntu-latest }
+          - { py: "3.10", toxenv: py310-asyncio, os: ubuntu-latest }
+          - { py: "3.11", toxenv: py311-epolls, os: ubuntu-latest }
+          - { py: "3.11", toxenv: py311-asyncio, os: ubuntu-latest }
+          - { py: "3.12", toxenv: py312-epolls, os: ubuntu-latest }
+          - { py: "3.12", toxenv: py312-asyncio, os: ubuntu-latest }
+          - { py: "3.13", toxenv: py313-epolls, os: ubuntu-24.04 }
+          - { py: "3.13", toxenv: py313-asyncio, os: ubuntu-24.04 }
+
+    steps:
+      - name: install system packages
+        run: sudo apt install -y --no-install-recommends ccache libffi-dev default-libmysqlclient-dev libpq-dev libssl-dev libzmq3-dev
+
+      - uses: actions/checkout@v4
+      - name: cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.toxenv }}-${{ hashFiles('.github/workflows/test.yaml', 'setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      - name: cache tox
+        uses: actions/cache@v4
+        with:
+          path: .tox
+          key: ${{ runner.os }}-tox-${{ matrix.toxenv }}-${{ hashFiles('tox.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-tox-
+            ${{ runner.os }}-
+
+      - name: setup python ${{ matrix.py }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py }}
+      - name: install codecov, tox
+        run: pip install codecov tox
+      - run: env
+      - name: run tests
+        run: tox --verbose --verbose -e ${{ matrix.toxenv }}
+      - name: codecov
+        run: codecov --flags=$(echo ${{ matrix.toxenv }} |tr -d -- '-.')
+
+  # Optional tests
+  optional-tests:
+    name: "Optional Test: ${{ matrix.toxenv }}"
+    continue-on-error: true
+    runs-on: ${{ matrix.os }}
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'eventlet/eventlet'
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { py: pypy3.9, toxenv: pypy3-epolls, os: ubuntu-20.04 }
 
     steps:
       - name: install system packages


### PR DESCRIPTION
Pypy job is failing without real reasons and logs are not useful. The CI just say: " The operation was canceled."

Lets ignore that job as we are going to abandon eventlet and we have urgent fix to merge before.