### PR TITLE
Move pypy job to ubuntu-24.04

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
           - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: ubuntu-latest }
           - { py: "3.13", toxenv: py313-epolls, ignore-error: false, os: ubuntu-24.04 }
           - { py: "3.13", toxenv: py313-asyncio, ignore-error: false, os: ubuntu-24.04 }
-          - { py: pypy3.9, toxenv: pypy3-epolls, ignore-error: true, os: ubuntu-20.04 }
+          - { py: pypy3.9, toxenv: pypy3-epolls, ignore-error: true, os: ubuntu-24.04 }
 
     steps:
       - name: install system packages


### PR DESCRIPTION
This instance of the job matrix is running on ubuntu 20.04 which has been actively discontinued by github: actions/runner-images#11101