### PR TITLE
Discontinues PyPy support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,19 +81,6 @@ jobs:
       - name: codecov
         run: codecov --flags=$(echo ${{ matrix.toxenv }} |tr -d -- '-.')
 
-  # Optional tests
-  optional-tests:
-    name: "Optional Test: ${{ matrix.toxenv }}"
-    continue-on-error: true
-    runs-on: ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'eventlet/eventlet'
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { py: pypy3.9, toxenv: pypy3-epolls, os: ubuntu-20.04 }
-
     steps:
       - name: install system packages
         run: sudo apt install -y --no-install-recommends ccache libffi-dev default-libmysqlclient-dev libpq-dev libssl-dev libzmq3-dev

--- a/eventlet/greenio/base.py
+++ b/eventlet/greenio/base.py
@@ -426,13 +426,6 @@ class GreenSocket:
     def __exit__(self, *args):
         self.close()
 
-    if "__pypy__" in sys.builtin_module_names:
-        def _reuse(self):
-            getattr(self.fd, '_sock', self.fd)._reuse()
-
-        def _drop(self):
-            getattr(self.fd, '_sock', self.fd)._drop()
-
 
 def _operation_on_closed_file(*args, **kwargs):
     raise ValueError("I/O operation on closed file")

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ envlist =
     pep8
     py39-openssl
     py39-dnspython1
-    pypy3-epolls
     py{39,310,311,312,313}-{selects,poll,epolls,asyncio}
 skipsdist = True
 


### PR DESCRIPTION
PyPy broke our CI and avoid us merging important patches. See:
- #1036 
- #1035 
- #1034
- #1031 
- etc

We are not PyPy users, and we have no enough resources to spend days maintaining compatibility with PyPy. We want to focus our time on our use cases.

Persons interested to continue maintaining the PyPy support are welcomed, and we could surely consider reintroducing its support if people volunteer to maintain it.

For now our priority is to ensure that we are able to offer a stable migration to our users, so we first have to ensure that we remain safe.