### PR TITLE
Replace explicit use of ubuntu-24.04

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,8 +44,8 @@ jobs:
           - { py: "3.11", toxenv: py311-asyncio, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-epolls, os: ubuntu-latest }
           - { py: "3.12", toxenv: py312-asyncio, os: ubuntu-latest }
-          - { py: "3.13", toxenv: py313-epolls, os: ubuntu-24.04 }
-          - { py: "3.13", toxenv: py313-asyncio, os: ubuntu-24.04 }
+          - { py: "3.13", toxenv: py313-epolls, os: ubuntu-latest }
+          - { py: "3.13", toxenv: py313-asyncio, os: ubuntu-latest }
 
     steps:
       - name: install system packages


### PR DESCRIPTION
ubuntu-latest was moved to ubuntu 24 in Dec 5, 2024[1].

[1] https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/