### PR TITLE
Handle ReferenceError except while count rlock

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -186,3 +186,4 @@ Thanks To
 * Ralf Haferkamp
 * Jake Tesler
 * Aayush Kasurde
+* Psycho Mantys, patch for exception handling on ReferenceError

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -528,7 +528,22 @@ def _green_existing_locks(rlock_type):
     # it's a useful warning, so we try to do it anyway for the benefit of those
     # users on 3.10 or later.
     gc.collect()
-    remaining_rlocks = len({o for o in gc.get_objects() if isinstance(o, rlock_type)})
+    remaining_rlocks = 0
+    for o in gc.get_objects():
+        try:
+            if isinstance(o, rlock_type):
+                remaining_rlocks += 1
+        except ReferenceError as exc:
+            import logging
+            import traceback
+
+            logger = logging.Logger("eventlet")
+            logger.error(
+                "Not increase rlock count, an exception of type "
+                + type(exc).__name__ + "occurred with the message '"
+                + str(exc) + "'. Traceback details: "
+                + traceback.format_exc()
+            )
     if remaining_rlocks:
         try:
             import _frozen_importlib
@@ -538,8 +553,21 @@ def _green_existing_locks(rlock_type):
             for o in gc.get_objects():
                 # This can happen in Python 3.12, at least, if monkey patch
                 # happened as side-effect of importing a module.
-                if not isinstance(o, rlock_type):
-                    continue
+                try:
+                    if not isinstance(o, rlock_type):
+                        continue
+                except ReferenceError as exc:
+                    import logging
+                    import traceback
+
+                    logger = logging.Logger("eventlet")
+                    logger.error(
+                        "No decrease rlock count, an exception of type "
+                        + type(exc).__name__ + "occurred with the message '"
+                        + str(exc) + "'. Traceback details: "
+                        + traceback.format_exc()
+                    )
+                    continue # if ReferenceError, skip this object and continue with the next one.
                 if _frozen_importlib._ModuleLock in map(type, gc.get_referrers(o)):
                     remaining_rlocks -= 1
                 del o


### PR DESCRIPTION
 # Handling `ReferenceError: weakly-referenced object no longer exists`

## Description

This pull request aims to address an uncommon issue where a `ReferenceError: weakly-referenced object no longer exists` occurs when accessing objects returned by `gc.get_objects()`. According to the [Python documentation](https://docs.python.org/3/library/exceptions.html#ReferenceError), this error is raised when attempting to access an object that has been garbage collected.

## Motivation and Context

The motivation for this change is a rare issue encountered during my development, where accessing objects returned by `gc.get_objects()` could lead to a `ReferenceError`. Although the condition to trigger this error might be difficult to reproduce, it is crucial to handle any exceptions to gracefully maintain the stability.

## Changes and Fixes

The proposed change involves adding a try-except block when counting remaining `RLocks` in the `patcher.py` file. This modification aims to catch potential instances where an object might already have been collected by the garbage collector (GC), thus preventing the raised `ReferenceError`.

By wrapping this specific line of code within a try-except, we ensure that any such exceptions are handled gracefully, allowing our application to continue functioning without interruptions or crashes due to unhandled errors.

## Testing and Validation

This change has been tested in controlled environments, albeit with a low frequency of occurrence. The added try-except block does not affect normal operations but provides an additional layer of protection against potential runtime errors. 

Further testing across different systems and configurations is recommended to validate the effectiveness of this fix.

## Impact and Risk Assessment

The impact of this change is minimal since it only affects specific lines of code within the `patcher.py` file, and the default handling for exceptions does not alter normal application behavior.

The risk associated with this change is low.