### PR TITLE
Fix threading monkey patching for Python 3.13 fork handling

### DIFF
--- a/eventlet/green/thread.py
+++ b/eventlet/green/thread.py
@@ -76,9 +76,17 @@ class _ThreadHandle:
 
 
 def _make_thread_handle(ident):
-    greenthread = greenlet.getcurrent()
-    assert ident == get_ident(greenthread)
-    return _ThreadHandle(greenthread=greenthread)
+    try:
+        gr = greenlet.getcurrent()
+        # Only enforce identity verification in non-fork scenarios
+        if ident == get_ident(gr):
+            return _ThreadHandle(greenthread=gr)
+        else:
+            # Fork detection: return "done" handle
+            return _ThreadHandle()
+    except greenlet.error:
+        # Handle cases with no current greenlet
+        return _ThreadHandle()
 
 
 def __spawn_green(function, args=(), kwargs=None, joinable=False):


### PR DESCRIPTION
Explanation of the fix:

 1. The issue occurred because Python 3.13 changed how threads are reinitialized
   after forking
 2. When threading._after_fork() attempts to rebuild thread objects, it calls
   _make_thread_handle()
 3. The previous implementation contained a strict assertion ident ==
   get_ident(greenthread)
 4. This assertion would fail because after forking:
    • The thread identities change
    • Green thread mapping isn't preserved across forks
    • The main thread recreation requires custom handling
 5. The fix modifies the conditional to:
    • Only perform identity verification when NOT in a fork scenario
    • Return a safe "done" thread handle during fork situations
    • Handle cases where no current greenlet exists
 6. This maintains the integrity of eventlet's thread emulation while accounting for
   Python 3.13's revised fork behavior

Note i have created this patch using aider, a terminal based AI coding tool
with my personal open-router key to access the deepseak-r1 and Gemini
flash LLMs.

deepseak drove the analysis of the the trackback and code base and
gemini applied the proposed changes to the files.


Closes #1030