### PR TITLE
Replace deprecated datetime.datetime.utcnow

### DIFF
--- a/eventlet/green/http/cookiejar.py
+++ b/eventlet/green/http/cookiejar.py
@@ -153,7 +153,7 @@ def time2isoz(t=None):
 
     """
     if t is None:
-        dt = datetime.datetime.utcnow()
+        dt = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     else:
         dt = datetime.datetime.utcfromtimestamp(t)
     return "%04d-%02d-%02d %02d:%02d:%02dZ" % (
@@ -171,7 +171,7 @@ def time2netscape(t=None):
 
     """
     if t is None:
-        dt = datetime.datetime.utcnow()
+        dt = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     else:
         dt = datetime.datetime.utcfromtimestamp(t)
     return "%s %02d-%s-%04d %02d:%02d:%02d GMT" % (


### PR DESCRIPTION
The utcnow function was deprecated in Python 3.12[1].

Note that all datetime instances are kept non-timezone-aware to keep backword-compatibility.

[1] https://docs.python.org/3.13/library/datetime.html#datetime.datetime.utcnow