### PR TITLE
Replace deprecated datetime.utcfromtimestamp

### DIFF
--- a/eventlet/green/http/cookiejar.py
+++ b/eventlet/green/http/cookiejar.py
@@ -155,7 +155,8 @@ def time2isoz(t=None):
     if t is None:
         dt = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     else:
-        dt = datetime.datetime.utcfromtimestamp(t)
+        dt = datetime.datetime.fromtimestamp(t, tz=datetime.timezone.utc
+            ).replace(tzinfo=None)
     return "%04d-%02d-%02d %02d:%02d:%02dZ" % (
         dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
 
@@ -173,7 +174,8 @@ def time2netscape(t=None):
     if t is None:
         dt = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     else:
-        dt = datetime.datetime.utcfromtimestamp(t)
+        dt = datetime.datetime.fromtimestamp(t, tz=datetime.timezone.utc
+            ).replace(tzinfo=None)
     return "%s %02d-%s-%04d %02d:%02d:%02d GMT" % (
         DAYS[dt.weekday()], dt.day, MONTHS[dt.month-1],
         dt.year, dt.hour, dt.minute, dt.second)


### PR DESCRIPTION
It was deprecated in Python 3.12 in favor of datetime.fromtimestamp[1].

[1] https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp