### PR TITLE
Prepare jobs and CI/CD for python 3.14

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ jobs:
   required-tests:
     name: "Required Tests: ${{ matrix.toxenv }}"
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.ignore-error || false }}
     # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012/5
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'eventlet/eventlet'
     timeout-minutes: 10
@@ -46,6 +47,8 @@ jobs:
           - { py: "3.12", toxenv: py312-asyncio, os: ubuntu-latest }
           - { py: "3.13", toxenv: py313-epolls, os: ubuntu-latest }
           - { py: "3.13", toxenv: py313-asyncio, os: ubuntu-latest }
+          - { py: "3.14.0-beta.3", toxenv: py314-epolls, os: ubuntu-latest, ignore-error: true }
+          - { py: "3.14.0-beta.3", toxenv: py314-asyncio, os: ubuntu-latest, ignore-error: true }
 
     steps:
       - name: install system packages
@@ -94,6 +97,7 @@ jobs:
         include:
           - { py: "3.12", toxenv: py312-asyncio, ignore-error: false, os: macos-latest }
           - { py: "3.13", toxenv: py313-asyncio, ignore-error: false, os: macos-latest }
+          - { py: "3.14.0-beta.3", toxenv: py314-asyncio, ignore-error: true, os: macos-latest }
           # This isn't working very well at the moment, but that might just be
           # tox config? In any case main focus is on asyncio so someone can
           # revisit separately.

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ envlist =
     pep8
     py39-openssl
     py39-dnspython1
-    py{39,310,311,312,313}-{selects,poll,epolls,asyncio}
+    py{39,310,311,312,313,314}-{selects,poll,epolls,asyncio}
 skipsdist = True
 
 [testenv:ipv6]
@@ -73,8 +73,8 @@ deps =
     py39-{selects,poll,epolls}: pyzmq==21.0.2
     py{39,310,311}: mysqlclient==2.0.3
     py39: psycopg2-binary==2.8.4
-    py{310,311}: psycopg2-binary==2.9.5
-    py{310,311}: pyzmq==25.0.0
+    py{310,311,312,313,314}: psycopg2-binary==2.9.10
+    py{310,311,312,313,314}: pyzmq==27
     dnspython1: dnspython<2
     asyncio: aiohttp
 usedevelop = True


### PR DESCRIPTION
Jobs are non-voting. The goal is simply to prepare the machinery to be ready for python 3.14, and hence, allowing us to test eventlet against this version, observe issues, and fix them early if possible.

Also updates versions of pyzmq and pyscopg-binary to work with 3.13+