### PR TITLE
Make database removal safer with IF EXISTS

### DIFF
--- a/tests/db_pool_test.py
+++ b/tests/db_pool_test.py
@@ -489,7 +489,7 @@ class MysqlConnectionPool:
 
     def drop_db(self):
         db = self._dbmodule.connect(**self._auth).cursor()
-        db.execute("drop database " + self._auth['db'])
+        db.execute("drop database IF EXISTS " + self._auth['db'])
         db.close()
         del db
 
@@ -560,7 +560,7 @@ class Psycopg2ConnectionPool:
         conn = self._dbmodule.connect(**auth)
         conn.set_isolation_level(0)
         db = conn.cursor()
-        db.execute("drop database " + self._auth['database'])
+        db.execute("drop database IF EXISTS " + self._auth['database'])
         db.close()
         conn.close()
 

--- a/tests/mysqldb_test.py
+++ b/tests/mysqldb_test.py
@@ -73,7 +73,7 @@ class TestMySQLdb(tests.LimitedTestCase):
 
     def drop_db(self):
         db = MySQLdb.connect(**self._auth).cursor()
-        db.execute("drop database " + self._auth['db'])
+        db.execute("drop database IF EXISTS " + self._auth['db'])
         db.close()
         del db
 


### PR DESCRIPTION
Use the SQL clause `DROP DATABASE IF EXISTS` instead of `DROP DATABASE` to avoid errors when the target database does not exist. This change improves robustness in test cleanup for MySQL and PostgreSQL connection pools.