### PR TITLE
Remove legacy setuptools configuration files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,6 @@ Documentation = "https://eventlet.readthedocs.io/"
 [project.optional-dependencies]
 dev = ["black", "isort", "pip-tools", "build", "twine", "pre-commit", "commitizen"]
 
-[tool.setuptools]
-packages = ['eventlet']
-
-[options.packages.find]
-where = "evenetlet"
-exclude = ["tests*", "benchmarks", "examples"]
 
 [tool.hatch]
 version.source = "vcs"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description_file = README.rst

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-import setuptools
-
-setuptools.setup()


### PR DESCRIPTION
Removes setup.py and setup.cfg as they contain redundant configuration that duplicates what's already properly defined in pyproject.toml with hatchling build backend. The setup.py only contained an empty setuptools.setup() call, and setup.cfg only specified description_file which is already configured as readme in pyproject.toml.

Also removes obsolete [tool.setuptools] and [options.packages.find] sections from pyproject.toml since hatchling handles package discovery automatically for standard project layouts.

This modernizes the packaging setup to use only pyproject.toml standards.

Related to: #1071 