### PR TITLE
Reduce warning in import

### DIFF
--- a/eventlet/__init__.py
+++ b/eventlet/__init__.py
@@ -105,4 +105,4 @@ class EventletDeprecationWarning(Warning):
 
 # If we're running tests this adds extra output that messes up some assertions.
 if os.environ.get("EVENTLET_TESTS") is None:
-    warnings.warn(_DEPRECATED, EventletDeprecationWarning, stacklevel=2)
+    warnings.warn(_DEPRECATED, DeprecationWarning, stacklevel=2)

--- a/eventlet/patcher.py
+++ b/eventlet/patcher.py
@@ -6,8 +6,10 @@ except ImportError:
     import imp
 import asyncio as asyncio_module
 import importlib
+import os
 import pkgutil
 import sys
+import warnings
 
 try:
     # Only for this purpose, it's irrelevant if `os` was already patched.
@@ -310,6 +312,13 @@ def monkey_patch(**on):
 
     It's safe to call monkey_patch multiple times.
     """
+
+    # If we're running tests this adds extra output that messes up some
+    # assertions.
+    if os.environ.get("EVENTLET_TESTS") is None:
+        warnings.warn(eventlet._DEPRECATED,
+                      eventlet.EventletDeprecationWarning,
+                      stacklevel=2)
 
     # Workaround for import cycle observed as following in monotonic
     # RuntimeError: no suitable implementation for this system


### PR DESCRIPTION
... and add migrate the "noisy" warning to actual patching.

Showing warning during import is problematic, rather than beneficial. Any projects importing eventlet indirectly now sees these warnings. We can suppress the warning by adding a filter, but we can't filter the specific warning because the warning class requires us to import the 'eventlet' module, which emits warning.