### PR TITLE
wsgi: Handle ENOTCONN

### DIFF
--- a/eventlet/wsgi.py
+++ b/eventlet/wsgi.py
@@ -924,11 +924,12 @@ Please use server.log.info instead.''')
 try:
     import ssl
     ACCEPT_EXCEPTIONS = (socket.error, ssl.SSLError)
-    ACCEPT_ERRNO = {errno.EPIPE, errno.ECONNRESET,
+    ACCEPT_ERRNO = {errno.EPIPE, errno.ECONNRESET, errno.ENOTCONN,
                     errno.ESHUTDOWN, ssl.SSL_ERROR_EOF, ssl.SSL_ERROR_SSL}
 except ImportError:
     ACCEPT_EXCEPTIONS = (socket.error,)
-    ACCEPT_ERRNO = {errno.EPIPE, errno.ECONNRESET, errno.ESHUTDOWN}
+    ACCEPT_ERRNO = {errno.EPIPE, errno.ECONNRESET, errno.ENOTCONN,
+                    errno.ESHUTDOWN}
 
 
 def socket_repr(sock):


### PR DESCRIPTION
`ENOTCONN` is sometimes raised when client connections are unexpectedly closed. The fix for [CVE-2023-40217](https://github.com/python/cpython/issues/108310) included in more recent versions of CPython also results in `ENOTCONN` being raised when an SSL connection is closed by the client while data remains on the buffer. These errors cause the eventlet WSGI server to terminate unexpectedly.

Add `ENOTCONN` to the list of accepted errnos to ensure this does not happen.

Fixes #943.