### PR TITLE
Fix 4 DNS tests that fail without /etc/resolv.conf

### DIFF
--- a/tests/greendns_test.py
+++ b/tests/greendns_test.py
@@ -299,13 +299,17 @@ class TestUdp(tests.LimitedTestCase):
 class TestProxyResolver(tests.LimitedTestCase):
 
     def test_clear(self):
-        rp = greendns.ResolverProxy()
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.conf')
+        tmp.write('nameserver 127.0.0.1\n')
+        tmp.flush()
+        rp = greendns.ResolverProxy(filename=tmp.name)
         assert rp._cached_resolver is None
         resolver = rp._resolver
         assert resolver is not None
         rp.clear()
         assert rp._resolver is not None
         assert rp._resolver != resolver
+        tmp.close()
 
     def _make_mock_hostsresolver(self):
         """A mocked HostsResolver"""
@@ -916,7 +920,7 @@ class TinyDNSTests(tests.LimitedTestCase):
         # https://github.com/eventlet/eventlet/issues/499
         # None means we don't want the server to find the IP
         with tests.dns_tcp_server(None) as dnsaddr:
-            resolver = Resolver()
+            resolver = Resolver(configure=False)
             resolver.nameservers = [dnsaddr[0]]
             resolver.nameserver_ports[dnsaddr[0]] = dnsaddr[1]
 
@@ -927,7 +931,7 @@ class TinyDNSTests(tests.LimitedTestCase):
         # https://github.com/eventlet/eventlet/issues/499
         expected_ip = "192.168.1.1"
         with tests.dns_tcp_server(expected_ip) as dnsaddr:
-            resolver = Resolver()
+            resolver = Resolver(configure=False)
             resolver.nameservers = [dnsaddr[0]]
             resolver.nameserver_ports[dnsaddr[0]] = dnsaddr[1]
             response = resolver.query('host.example.com', 'a', tcp=True)

--- a/tests/isolated/socket_resolve_green.py
+++ b/tests/isolated/socket_resolve_green.py
@@ -3,11 +3,22 @@ __test__ = False
 if __name__ == '__main__':
     import eventlet
     eventlet.monkey_patch(all=True)
+    import os
     import socket
+    import tempfile
     import time
     import dns.message
     import dns.query
     import dns.flags
+    from eventlet.support import greendns
+
+    # Ensure the global resolver proxy works even without /etc/resolv.conf
+    # (e.g. on Debian buildd servers). See https://github.com/eventlet/eventlet/issues/963
+    if not os.path.exists('/etc/resolv.conf'):
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.conf', delete=False)
+        tmp.write('nameserver 127.0.0.1\n')
+        tmp.close()
+        greendns.resolver._filename = tmp.name
 
     n = 10
     delay = 0.01


### PR DESCRIPTION
## Summary
- Fix 4 unit tests (`test_clear`, `test_raise_dns_tcp`, `test_noraise_dns_tcp`, `test_dns_methods_are_green`) that depend on `/etc/resolv.conf` being present
- On systems without `/etc/resolv.conf` (e.g. Debian buildd servers), `dns.resolver.Resolver()` raises `NoResolverConfiguration`, causing these tests to fail

## Changes
- **`test_clear`**: use a temporary resolv.conf instead of the system default
- **`test_raise_dns_tcp` / `test_noraise_dns_tcp`**: use `Resolver(configure=False)` since these tests already set their own nameservers manually
- **`socket_resolve_green.py`**: provide a fallback temporary resolv.conf when the system file is missing

## Test plan
- [x] All 4 affected tests pass with `tox -e py314-selects`

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)