### PR TITLE
Fix compatibility with greenlet >= 3.4

### DIFF
--- a/eventlet/green/thread.py
+++ b/eventlet/green/thread.py
@@ -6,6 +6,8 @@ from eventlet.timeout import with_timeout
 from eventlet.lock import Lock
 import sys
 
+_real_get_ident = __thread.get_ident
+
 
 __patched__ = ['Lock', 'LockType', '_ThreadHandle', '_count',
                '_get_main_thread_ident', '_local', '_make_thread_handle',
@@ -36,7 +38,10 @@ def _count():
 
 def get_ident(gr=None):
     if gr is None:
-        return id(greenlet.getcurrent())
+        try:
+            return id(greenlet.getcurrent())
+        except RuntimeError:
+            return _real_get_ident()
     else:
         return id(gr)
 

--- a/eventlet/semaphore.py
+++ b/eventlet/semaphore.py
@@ -94,7 +94,13 @@ class Semaphore:
         if not blocking and self.locked():
             return False
 
-        current_thread = eventlet.getcurrent()
+        try:
+            current_thread = eventlet.getcurrent()
+        except RuntimeError:
+            if self.counter > 0:
+                self.counter -= 1
+                return True
+            return False
 
         if self.counter <= 0 or self._waiters:
             if current_thread not in self._waiters:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     'dnspython >= 1.15.0',
-    'greenlet < 3.4',  # 3.5 is causing test failures
+    'greenlet >= 1.0',
 ]
 
 [project.urls]


### PR DESCRIPTION
Since greenlet 3.5.1, greenlet.getcurrent() raises RuntimeError during interpreter shutdown instead of returning None. This broke eventlet's monkeypatched code paths that run during finalization: Python's logging module triggers weakref callbacks during shutdown that acquire locks, which flow through eventlet's patched threading.Lock (Semaphore) and thread.get_ident — both of which call greenlet.getcurrent().

Guard get_ident() and Semaphore.acquire() against this RuntimeError. In get_ident(), fall back to the real _thread.get_ident() captured at import time (before monkeypatching). In Semaphore.acquire(), do a simple non-blocking counter decrement since interpreter finalization is single-threaded.

Remove the greenlet < 3.4 version pin that was working around this.