### PR TITLE
CI: Run apt-get update before installing system packages

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,9 @@ jobs:
 
     steps:
       - name: install system packages
-        run: sudo apt install -y --no-install-recommends ccache libffi-dev default-libmysqlclient-dev libpq-dev libssl-dev libzmq3-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ccache libffi-dev default-libmysqlclient-dev libpq-dev libssl-dev libzmq3-dev
 
       - uses: actions/checkout@v5
       - name: cache pip


### PR DESCRIPTION
The GitHub Actions runner image ships a cached apt package index that can become stale between image releases. When Ubuntu mirrors publish new package versions, the old URLs return 404, causing all Linux CI jobs to fail at the install step.